### PR TITLE
dart: use Uint32List instead of a regular list

### DIFF
--- a/loops/dart/code.dart
+++ b/loops/dart/code.dart
@@ -1,13 +1,12 @@
 import 'dart:math';
+import 'dart:typed_data';
 
 void main(List<String> args) {
   final u = int.parse(args[0]); // Get an input number from the command line
   final r = Random().nextInt(10000); // Get a random integer 0 <= r < 10k
 
-  final List<int> a = List.filled(
+  final List<int> a = Uint32List(
     10000,
-    0,
-    growable: false,
   ); // Array of 10k elements initialized to 0
   for (int i = 0; i < 10000; i++) {
     // 10k outer loop iterations


### PR DESCRIPTION
Hi!

The previous list is quite inefficient when we reassign a value of the "array" quite often or when we try to access it.

`Uint32List` is made for this use case. It's more or less a C array. It has a fixed size and can't be extended. This one only accept unsigned 32-bit integers. We can use 16/32/64 bits if needed.

On my laptop, I have 20% of gain! From ~2500ms to ~2000ms .