### PR TITLE
Improve Go loops

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -1,5 +1,5 @@
 clang -O3 c/code.c -o c/code
-go build -o go/code go/code.go
+go build -ldflags "-s -w" -o go/code go/code.go
 javac jvm/code.java
 RUSTFLAGS="-Zlocation-detail=none" cargo +nightly build --manifest-path rust/Cargo.toml --release
 kotlinc -include-runtime kotlin/code.kt -d kotlin/code.jar

--- a/loops/go/code.go
+++ b/loops/go/code.go
@@ -9,11 +9,11 @@ import (
 func main() {
   input, e := strconv.Atoi(os.Args[1]) // Get an input number from the command line
   if e != nil { panic(e) }
-  u := int(input)
-  r := int(rand.Intn(10000))           // Get a random number 0 <= r < 10k
-  var a[10000]int                      // Array of 10k elements initialized to 0
-  for i := 0; i < 10000; i++ {         // 10k outer loop iterations
-    for j := 0; j < 100000; j++ {      // 100k inner loop iterations, per outer loop iteration
+  u := int32(input)
+  r := int32(rand.Intn(10000))           // Get a random number 0 <= r < 10k
+  var a[10000]int32                      // Array of 10k elements initialized to 0
+  for i := int32(0); i < 10000; i++ {         // 10k outer loop iterations
+    for j := int32(0); j < 100000; j++ {      // 100k inner loop iterations, per outer loop iteration
       a[i] = a[i] + j%u                // Simple sum
     }
     a[i] += r                          // Add a random value to each element in array


### PR DESCRIPTION
I changed the type from `int` to `int32`, on my laptop the time improved from 15 seconds to 5 seconds when running the binary with input 40.

This is a bit fairer compared to other languages like Java or Kotlin, whose implementations in this repository use 32-bit integer types.

I also added the flag `-ldflags "-s -w"` to the `go build` command in `compile.sh` to remove the symbol and debug info, this reduces the size of the binary.