### PR TITLE
10x Python perf with `sum` and `itertools`

### DIFF
--- a/loops/py/code.py
+++ b/loops/py/code.py
@@ -1,10 +1,21 @@
 import sys
-import random
-u = int(sys.argv[1])         # Get an input number from the command line
-r = random.randint(0, 10000) # Get a random number 0 <= r < 10k
-a  = [0] * 10000             # Array of 10k elements initialized to 0
-for i in range(10000):       # 10k outer loop iterations
-  for j in range(100000):    # 100k inner loop iterations, per outer loop iteration
-    a[i] = a[i] + j%u        # Simple sum
-  a[i] = a[i] + r            # Add a random value to each element in array
-print(a[r])                  # Print out a single element from the arra
+from itertools import cycle, islice
+from random import randint
+
+
+def main():
+    u = int(sys.argv[1])  # Get an input number from the command line
+    r = randint(0, 10000)  # Get a random number 0 <= r < 10k
+    a = [0] * 10000  # Array of 10k elements initialized to 0
+    # 10k outer loop iterations
+    for i in range(len(a)):
+        # 100k inner loop iterations, per outer loop iteration
+        a[i] = sum(islice(cycle(range(u)), 100000))
+        # Add a random value to each element in array
+        a[i] += r
+
+    print(a[r])  # Print out a single element from the array
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Just to make Python less shamefully slow

## Changes

* Sum up the `i % u` range as an iterator. This yields about 10-20x improvement. (On my M1 mac: ~4.2 seconds)
* Introduce a function scope to reduce variable lookup time (minor)

And if we're allowed to "cheat" by optimizing by hand, then this reduces Python to about 10-20ms:

```python
import sys
from itertools import cycle, islice, repeat
from random import randint


def main():
    u = int(sys.argv[1])  # Get an input number from the command line
    r = randint(0, 10000)  # Get a random number 0 <= r < 10k
    a = [0] * 10000  # Array of 10k elements initialized to 0
    # 10k outer loop iterations
    a = list(repeat(sum(islice(cycle(range(u)), 100000)) + r, 10000))
    print(a[r])  # Print out a single element from the array

if __name__ == "__main__":
    main()
```