### PR TITLE
Use int32 instead of int

### DIFF
--- a/loops/go/code.go
+++ b/loops/go/code.go
@@ -1,7 +1,7 @@
 package main
 import (
     "fmt"
-    "math/rand"
+    "math/rand/v2"
     "strconv"
     "os"
 )
@@ -9,14 +9,14 @@ import (
 func main() {
   input, e := strconv.Atoi(os.Args[1]) // Get an input number from the command line
   if e != nil { panic(e) }
-  u := int(input)
-  r := int(rand.Intn(10000))           // Get a random number 0 <= r < 10k
-  var a[10000]int                      // Array of 10k elements initialized to 0
-  for i := 0; i < 10000; i++ {         // 10k outer loop iterations
-    for j := 0; j < 100000; j++ {      // 100k inner loop iterations, per outer loop iteration
-      a[i] = a[i] + j%u                // Simple sum
+  u := int32(input)
+  r := int32(rand.Int32N(10000))         // Get a random number 0 <= r < 10k
+  var a[10000]int32                      // Array of 10k elements initialized to 0
+  for i := int32(0); i < 10000; i++ {    // 10k outer loop iterations
+    for j := int32(0); j < 100000; j++ { // 100k inner loop iterations, per outer loop iteration
+      a[i] = a[i] + j%u                  // Simple sum
     }
-    a[i] += r                          // Add a random value to each element in array
+    a[i] += r                            // Add a random value to each element in array
   }
-  fmt.Println(a[r])                    // Print out a single element from the array
+  fmt.Println(a[r])                      // Print out a single element from the array
 }


### PR DESCRIPTION
Using int32 instead of int offers a significant performance uplift in Go. On my computer it went from 1.51s to 1.29s (tied with C/Rust)