### PR TITLE
Speed up javascript with eval

### DIFF
--- a/loops/js/code.js
+++ b/loops/js/code.js
@@ -1,10 +1,11 @@
 const u = Number(process.argv[2]);           // Get an input number from the command line
 const r = Math.floor(Math.random() * 10000); // Get a random number 0 <= r < 10k
 const a = new Int32Array(10000);             // Array of 10k elements initialized to 0
+eval(`
 for (let i = 0; i < 10000; i++) {          // 10k outer loop iterations
   for (let j = 0; j < 100000; j++) {       // 100k inner loop iterations, per outer loop iteration
     a[i] = a[i] + j%u;                     // Simple sum
   }
   a[i] += r;                               // Add a random value to each element in array
-}
+}`)
 console.log(a[r]);                         // Print out a single element from the array

--- a/loops/js/code.js
+++ b/loops/js/code.js
@@ -1,6 +1,6 @@
-var u = Number(process.argv[2]);           // Get an input number from the command line
-var r = Math.floor(Math.random() * 10000); // Get a random number 0 <= r < 10k
-var a = new Int32Array(10000);             // Array of 10k elements initialized to 0
+const u = Number(process.argv[2]);           // Get an input number from the command line
+const r = Math.floor(Math.random() * 10000); // Get a random number 0 <= r < 10k
+const a = new Int32Array(10000);             // Array of 10k elements initialized to 0
 for (let i = 0; i < 10000; i++) {          // 10k outer loop iterations
   for (let j = 0; j < 100000; j++) {       // 100k inner loop iterations, per outer loop iteration
     a[i] = a[i] + j%u;                     // Simple sum


### PR DESCRIPTION
This change speeds up the javascript loops when run in bun on my machine.

Before the change

```
Node = 2.41users
0inputs+0outputss
Node = 2.39users
0inputs+0outputss
Node = 2.42users
0inputs+0outputss

Bun = 2.09users
0inputs+0outputss
Bun = 2.10users
0inputs+0outputss
Bun = 2.08users
0inputs+0outputss
```

After the change

```
Node = 2.39users
0inputs+0outputss
Node = 2.42users
0inputs+0outputss
Node = 2.39users
0inputs+0outputss

Bun = 1.84users
0inputs+0outputss
Bun = 1.84users
0inputs+0outputss
Bun = 1.87users
0inputs+0outputss
```