### PR TITLE
Fix the unfair betwenn C and Rust code (unsigned 32 bit interger) and use stable toolchain

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -1,7 +1,7 @@
 clang -O3 c/code.c -o c/code
 go build -o go/code go/code.go
 javac jvm/code.java
-RUSTFLAGS="-Zlocation-detail=none" cargo +nightly build --manifest-path rust/Cargo.toml --release
+cargo build --manifest-path rust/Cargo.toml --release
 kotlinc -include-runtime kotlin/code.kt -d kotlin/code.jar
 #kotlinc-native -include-runtime kotlin/code.kt -d kotlin/code
 dart compile exe dart/code.dart -o dart/code --target-os=macos

--- a/fibonacci/rust/code.rs
+++ b/fibonacci/rust/code.rs
@@ -1,5 +1,13 @@
+fn fibonacci(n: u32) -> u32 {
+    match n {
+        0 => 0,
+        1 => 1,
+        _ => fibonacci(n - 1) + fibonacci(n - 2),
+    }
+}
+
 fn main() {
-    let u: i32 = std::env::args()
+    let u: u32 = std::env::args()
         .nth(1)
         .unwrap()
         .parse()
@@ -9,12 +17,4 @@ fn main() {
         r += fibonacci(i);
     }
     println!("{}", r);
-}
-
-fn fibonacci(n: i32) -> i32 {
-    match n {
-        0 => 0,
-        1 => 1,
-        _ => fibonacci(n - 1) + fibonacci(n - 2),
-    }
 }

--- a/loops/rust/code.rs
+++ b/loops/rust/code.rs
@@ -1,18 +1,19 @@
-use rand::Rng;
+use rand::{thread_rng, Rng};
 fn main() {
-    let n: usize = std::env::args()             // Get an input number from the command line
+    let n: u32 = std::env::args()           // Get an input number from the command line
         .nth(1)
         .unwrap()
         .parse()
         .unwrap();
-    let r: usize = rand::thread_rng()           // Get a random number 0 <= r < 10k
-        .gen_range(0..10000);
-    let mut a = [0; 10000];                     // Array of 10k elements initialized to 0
-    for i in 0..10000 {                         // 10k outer loop iterations
-        for j in 0..100000 {                    // 100k inner loop iterations, per outer loop iteration
+    
+    let r:u32 = thread_rng().gen_range(0..10000);// Get a random number 0 <= r < 10k
+        
+    let mut a = [0u32; 10000];    // Array of 10k elements initialized to 0
+    for i in 0..10000 {                  // 10k outer loop iterations
+        for j in 0..100000 {               // 100k inner loop iterations, per outer loop iteration
             a[i] = a[i] + j % n;                // Simple sum
         }
         a[i] += r;                              // Add a random value to each element in array
     }
-    println!("{}", a[r]);                       // Print out a single element from the array
+    println!("{}", a[r as usize]);              // Print out a single element from the array
 }


### PR DESCRIPTION
Hello,
I have fixed the rust performance problem, the original code was using size  as the size of integer for the tab A and the C code is using integer of 32 bits.
The size type is the type that matches the size of a pointer to refer to any location in memory, so 32 bits on 32 bit platform and 64 bits on most computer today.

I have fixed  that by just replacing usize by u32
So compiler llvm for both can optimize the code the same way.

On my machine
Before: 
C: 1.83 sec
Rust: 2.01 sec
After: 
C: 1.83 sec
Rust: 1.70 sec

Cool!

I have also removed the necessary of nightly build so every one can test and removed the-Zlocation-detail=none flag which is only supported by nightly and does nothing for performance for this type of programme and it's generally nano benefits.