### PR TITLE
Php use typehints for fair comparation

### DIFF
--- a/fibonacci/php/code.php
+++ b/fibonacci/php/code.php
@@ -1,6 +1,6 @@
 <?php
 
-function fibonacci($n)
+function fibonacci(int $n): int
 {
     if ($n == 0) return 0;
     if ($n == 1) return 1;


### PR DESCRIPTION
Php function signature is missing types.
With types should be more fair comparation to C as interpreter shouldn't be guessing dynamic type and hit jit as well