### PR TITLE
Update README: Add explanation for script execution times

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To run one of the benchmarks:
 
 The numbers represent the real execution time (wall-clock time) it took for each language to execute the given task. **A lower number indicates better performance.**
 
-`bash ../run.sh` runs each program three times using the `runOnce` function and `awk` captures the real execution time; however, only the third run is recorded and outputted.
+`bash ../run.sh` runs each program three times using the `runOnce` function and `awk` captures the real execution time.
 
 ## Adding
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ To run one of the benchmarks:
 
 4. For good measure, execute `$ bash ../clean.sh` when finished.
 
+### Interpretation
+
+The numbers represent the real execution time (wall-clock time) it took for each language to execute the given task. **A lower number indicates better performance.**
+
+`bash ../run.sh` runs each program three times using the `runOnce` function and `awk` captures the real execution time; however, only the third run is recorded and outputted.
+
 ## Adding
 
 To add a language:


### PR DESCRIPTION
- Added an explanation of the numbers output by `run.sh` to clarify what they represent.
- Highlighted that lower numbers indicate better performance.
- Clarified that only the third run is outputted by the script.

Closes #64