### PR TITLE
Match Go integer size to C/Rust/Java integer size

### DIFF
--- a/loops/go/code.go
+++ b/loops/go/code.go
@@ -9,11 +9,11 @@ import (
 func main() {
   input, e := strconv.Atoi(os.Args[1]) // Get an input number from the command line
   if e != nil { panic(e) }
-  u := int(input)
-  r := int(rand.Intn(10000))           // Get a random number 0 <= r < 10k
-  var a[10000]int                      // Array of 10k elements initialized to 0
-  for i := 0; i < 10000; i++ {         // 10k outer loop iterations
-    for j := 0; j < 100000; j++ {      // 100k inner loop iterations, per outer loop iteration
+  u := int32(input)
+  r := int32(rand.Intn(10000))           // Get a random number 0 <= r < 10k
+  var a[10000]int32                      // Array of 10k elements initialized to 0
+  for i := int32(0); i < 10000; i++ {         // 10k outer loop iterations
+    for j := int32(0); j < 100000; j++ {      // 100k inner loop iterations, per outer loop iteration
       a[i] = a[i] + j%u                // Simple sum
     }
     a[i] += r                          // Add a random value to each element in array


### PR DESCRIPTION
Go's int type will default to 64 bit on 64 bit machines, making it seem slower compared to other languages where 32 bit int is the default on modern machines.

Explicit integer sizes should probably be used on other languages as well for consistency and reproducibility.

There are other generated code output changes due to language differences but this is the lion's share and 2nd place seems to be the GC which is much more representative of expectations.