### PR TITLE
Enable JIT and disable XDebug for PHP

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -11,8 +11,6 @@ function run {
   runOnce "$1" "$2"
 }
 
-cd loops
-
 run "Kotlin" "java -jar kotlin/code.jar 40"
 run "C" "./c/code 40" 
 run "Go" "./go/code 40" 

--- a/run.sh
+++ b/run.sh
@@ -11,6 +11,8 @@ function run {
   runOnce "$1" "$2"
 }
 
+cd loops
+
 run "Kotlin" "java -jar kotlin/code.jar 40"
 run "C" "./c/code 40" 
 run "Go" "./go/code 40" 
@@ -21,7 +23,7 @@ run "Deno" "deno ./js/code.js 40"
 run "PyPy" "pypy ./py/code.py 40" 
 run "Java" "java jvm.code 40"
 run "Ruby" "ruby ./ruby/code.rb 40"
-run "PHP" "php ./php/code.php 40"
+run "PHP" "php -dopcache.jit=on -dopcache.jit_buffer_size=64M -dopcache.enable_cli=1 -dxdebug.mode=off ./php/code.php 40"
 run "R" "Rscript ./r/code.R 40"
 run "Python" "python3 ./py/code.py 40" 
 run "Dart" "./dart/code 40"


### PR DESCRIPTION
I enabled JIT and disabled XDebug on PHP to make the benchmark a bit more fair. A debugger can severely slow down the execution and other languages have JIT enabled.