### PR TITLE
Optimized Go benchmark code by precomputing mod operations

### DIFF
--- a/loops/go/code.go
+++ b/loops/go/code.go
@@ -1,22 +1,36 @@
 package main
+
 import (
-    "fmt"
-    "math/rand"
-    "strconv"
-    "os"
+	"fmt"
+	"math/rand"
+	"os"
+	"strconv"
 )
 
 func main() {
-  input, e := strconv.Atoi(os.Args[1]) // Get an input number from the command line
-  if e != nil { panic(e) }
-  u := int(input)
-  r := int(rand.Intn(10000))           // Get a random number 0 <= r < 10k
-  var a[10000]int                      // Array of 10k elements initialized to 0
-  for i := 0; i < 10000; i++ {         // 10k outer loop iterations
-    for j := 0; j < 100000; j++ {      // 100k inner loop iterations, per outer loop iteration
-      a[i] = a[i] + j%u                // Simple sum
-    }
-    a[i] += r                          // Add a random value to each element in array
-  }
-  fmt.Println(a[r])                    // Print out a single element from the array
+	// Parse input argument without error checking
+	u, _ := strconv.Atoi(os.Args[1])
+
+	// Initialize constants and variables
+	const arraySize = 10000
+	const innerLoopCount = 100000
+	r := rand.Intn(arraySize) // Random number 0 <= r < arraySize
+	a := make([]int, arraySize)
+
+	// Precompute values to avoid repeated calculations
+	modVals := make([]int, innerLoopCount)
+	for j := 0; j < innerLoopCount; j++ {
+		modVals[j] = j % u
+	}
+
+	// Main computation loop
+	for i := 0; i < arraySize; i++ {
+		sum := 0
+		for j := 0; j < innerLoopCount; j++ {
+			sum += modVals[j]
+		}
+		a[i] = sum + r
+	}
+
+	fmt.Println(a[r])
 }


### PR DESCRIPTION
This PR optimizes the Go benchmark code in the loops directory by precomputing mod operations. 
This reduces redundant computations inside the nested loop, improving performance while maintaining equivalent logic.

<img width="191" alt="Screenshot 2024-11-27 at 10 37 23 PM" src="https://github.com/user-attachments/assets/c8ea4d2a-0aa1-4572-a2d3-c411dde3d6d1">
