### PR TITLE
Optimizing PHP loops benchmark by using reference operator

### DIFF
--- a/loops/php/code.php
+++ b/loops/php/code.php
@@ -3,10 +3,10 @@
 $u = (int) $argv[1];                                # Get an input number from the command line
 $r = rand(0, 10000);                                # Get a random number 0 <= r < 10k
 $a = array_fill(0, 10000, 0);    # Array of 10k elements initialized to 0
-for ($i = 0; $i < 10000; $i++) {                    # 10k outer loop iterations
+foreach ($a as &$c) {                   # 10k outer loop iterations
     for ($j = 0; $j < 100000; $j++) {               # 100k inner loop iterations, per outer loop iteration
-        $a[$i] += $j%$u;                    # Simple sum
+        $c += $j%$u;                    # Simple sum
     }
-    $a[$i] += $r;                                   # Add a random value to each element in array
+    $c += $r;                                   # Add a random value to each element in array
 }
 echo $a[$r];                                        # Print out a single element from the array


### PR DESCRIPTION
Hey guys, I've tested this new implementation for PHP and I'm getting a little speedup by using the [PHP reference operator](https://www.php.net/manual/en/language.references.php).

The concept here is because we already have the entire array initialized by the array_fill function, so why not access each position by their reference to make each change without need to re-access the same $a[$i] value so much times.

PS.: It's possible to do with "for" instead "foreach" too, creating a new temp variable by de-referencing the $a[$i] value with something like $c =& $a[$i], but I used "foreach" because I know that have some discussions around them 😂

Please test my changes to see if it's a really speedup!

## Before:
![php-benchmark-loops-before-optimization](https://github.com/user-attachments/assets/d094c1bc-2dca-4e4e-9d85-c192f52bdf4a)

## After:
![php-benchmark-loops-after-optimization](https://github.com/user-attachments/assets/1a73faa6-c283-4835-a7a4-8c5d5e5ee5d4)
