### PR TITLE
Add vectorized version of java loop

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -1,6 +1,6 @@
 clang -O3 c/code.c -o c/code
 go build -ldflags "-s -w" -o go/code go/code.go
-javac jvm/code.java
+javac --add-modules jdk.incubator.vector jvm/code.java
 cargo build --manifest-path rust/Cargo.toml --release
 kotlinc -include-runtime kotlin/code.kt -d kotlin/code.jar
 #kotlinc-native -include-runtime kotlin/code.kt -d kotlin/code

--- a/loops/jvm/code.java
+++ b/loops/jvm/code.java
@@ -2,17 +2,23 @@ package jvm;
 
 import java.util.Random;
 
-public class code {
+import jdk.incubator.vector.IntVector;
+import jdk.incubator.vector.VectorOperators;
 
+public class code {
     public static void main(String[] args) {
         var u = Integer.parseInt(args[0]); // Get an input number from the command line
         var r = new Random().nextInt(10000); // Get a random number 0 <= r < 10k
+        var rv = IntVector.SPECIES_PREFERRED.broadcast(r); // Broadcast scalar to vector
         var a = new int[10000]; // Array of 10k elements initialized to 0
-        for (var i = 0; i < 10000; i++) { // 10k outer loop iterations
-            for (var j = 0; j < 100000; j++) { // 100k inner loop iterations, per outer loop iteration
-                a[i] = a[i] + j % u; // Simple sum
+        for (var i = 0; i < 10000; i += IntVector.SPECIES_PREFERRED.length()) { // 10k outer loop iterations
+            var av = IntVector.SPECIES_PREFERRED.fromArray(a, i); // Load vector from array
+            for (var j = 0; j < 100000; j ++) { // 100k inner loop iterations, per outer loop iteration
+                var jv = IntVector.SPECIES_PREFERRED.broadcast(j % u);  // Broadcast modulo of scalar to vector
+                av = av.add(jv); // Vectorized addition
             }
-            a[i] += r; // Add a random value to each element in array
+            av = av.add(rv); // Add a random value to each element in array
+            av.reinterpretAsInts().intoArray(a, i); // Store vector back to array
         }
         System.out.println(a[r]); // Print out a single element from the array
     }

--- a/run.sh
+++ b/run.sh
@@ -1,7 +1,7 @@
 function runOnce  {
   { /usr/bin/time $2 ; } 2> /tmp/o 1> /dev/null
   printf "$1 = "
-  cat /tmp/o | awk -v N=1 '{print $N"s"}'
+  cat /tmp/o | grep user | awk -v N=1 '{print $N"s"}'
 }
 
 function run {
@@ -20,7 +20,7 @@ run "Node" "node ./js/code.js 40"
 run "Bun" "bun ./js/code.js 40"
 run "Deno" "deno ./js/code.js 40"
 run "PyPy" "pypy ./py/code.py 40"
-run "Java" "java jvm.code 40"
+run "Java" "java --add-modules jdk.incubator.vector jvm.code 40"
 run "Scala" "./scala/code 40"
 run "Ruby" "ruby ./ruby/code.rb 40"
 run "PHP JIT" "php -dopcache.enable_cli=1 -dopcache.jit=on -dopcache.jit_buffer_size=64M ./php/code.php 40"


### PR DESCRIPTION
This pull request includes several changes to improve the performance and functionality of the Java code by utilizing the `jdk.incubator.vector` module. Additionally, there are minor adjustments to the `run.sh` script to accommodate these changes.


With these changes java impl is ~1.8x faster than c on my machine.
```
C = 1.21users
C = 1.22users
C = 1.22users

Go = 1.24users
Go = 1.24users
Go = 1.22users

Rust = 1.21users
Rust = 1.21users
Rust = 1.22users

Java = 0.78users
Java = 0.76users
Java = 0.76users
```

### Enhancements to Java code:

* [`compile.sh`](diffhunk://#diff-24d024fa911cc01760d679370d8ea8711230f073fde3e721a59e292b825252c4L3-R3): Updated the `javac` command to include the `jdk.incubator.vector` module for vector API support.
* [`loops/jvm/code.java`](diffhunk://#diff-d2611cfdd8159d2ed1167c1de75cc7b11aed3cb01d8981de431cc87056d539f4L5-R21): Refactored the code to use the vector API for improved performance. This includes broadcasting scalars to vectors, vectorized addition, and storing vectors back to arrays.

### Adjustments to run script:

* [`run.sh`](diffhunk://#diff-d31ce0453051853c17ba2a5225b3d1bfab548e095bab0967d6acfd1b3ce1b35dL4-R4): Modified the `runOnce` function to filter for the `user` time in the output, this was required because java includes a incubator warning to stderr.
* [`run.sh`](diffhunk://#diff-d31ce0453051853c17ba2a5225b3d1bfab548e095bab0967d6acfd1b3ce1b35dL23-R23): Updated the Java run command to include the `jdk.incubator.vector` module.