### PR TITLE
Make loops comparable in go and c

### DIFF
--- a/loops/go/code.go
+++ b/loops/go/code.go
@@ -8,19 +8,19 @@ import (
 )
 
 func main() {
-	input, e := strconv.Atoi(os.Args[1]) // Get an input number from the command line
+	input, e := strconv.Atoi(os.Args[1])   // Get an input number from the command line
 	if e != nil {
 		panic(e)
 	}
-	u := input
-	r := int32(rand.Intn(10000))         // Get a random number 0 <= r < 10k
-	var a [10000]int32                   // Array of 10k elements initialized to 0
-	for i := 0; i < 10000; i++ {         // 10k outer loop iterations
-		k := a[i]                          // Use a local variable to loop in a register
-		for j := 0; j < 100000; j++ {      // 100k inner loop iterations, per outer loop iteration
-			k = k + int32(j%u)               // Simple sum
+	u := int32(input)
+	r := int32(rand.Intn(10000))           // Get a random number 0 <= r < 10k
+	var a [10000]int32                     // Array of 10k elements initialized to 0
+	for i := int32(0); i < 10000; i++ {    // 10k outer loop iterations
+		k := a[i]                            // Use a local variable to loop in a register
+		for j := int32(0); j < 100000; j++ { // 100k inner loop iterations, per outer loop iteration
+			k = k + j%u                        // Simple sum
 		}
-		a[i] += k + r                      // Add a random value to each element in array
+		a[i] += k + r                        // Add a random value to each element in array
 	}
-	fmt.Println(a[r])                    // Print out a single element from the array
+	fmt.Println(a[r])                      // Print out a single element from the array
 }

--- a/loops/go/code.go
+++ b/loops/go/code.go
@@ -1,22 +1,26 @@
 package main
+
 import (
-    "fmt"
-    "math/rand"
-    "strconv"
-    "os"
+	"fmt"
+	"math/rand"
+	"os"
+	"strconv"
 )
 
 func main() {
-  input, e := strconv.Atoi(os.Args[1]) // Get an input number from the command line
-  if e != nil { panic(e) }
-  u := int32(input)
-  r := int32(rand.Intn(10000))           // Get a random number 0 <= r < 10k
-  var a[10000]int32                      // Array of 10k elements initialized to 0
-  for i := int32(0); i < 10000; i++ {         // 10k outer loop iterations
-    for j := int32(0); j < 100000; j++ {      // 100k inner loop iterations, per outer loop iteration
-      a[i] = a[i] + j%u                // Simple sum
-    }
-    a[i] += r                          // Add a random value to each element in array
-  }
-  fmt.Println(a[r])                    // Print out a single element from the array
+	input, e := strconv.Atoi(os.Args[1]) // Get an input number from the command line
+	if e != nil {
+		panic(e)
+	}
+	u := input
+	r := int32(rand.Intn(10000))         // Get a random number 0 <= r < 10k
+	var a [10000]int32                   // Array of 10k elements initialized to 0
+	for i := 0; i < 10000; i++ {         // 10k outer loop iterations
+		k := a[i]                          // Use a local variable to loop in a register
+		for j := 0; j < 100000; j++ {      // 100k inner loop iterations, per outer loop iteration
+			k = k + int32(j%u)               // Simple sum
+		}
+		a[i] += k + r                      // Add a random value to each element in array
+	}
+	fmt.Println(a[r])                    // Print out a single element from the array
 }


### PR DESCRIPTION
The clang compiler performs an optimization called Scalar Replacement of Aggregates on the C code which essentially means that it rewrites the c code to use a local variable (which is stored in a register) just for iterating through the inner loop with 100,000 sums of `j%u`, and then assigns it back to the array of int32 values.

The go complier doesn't currently perform the same optimization. But, it's trivial to rewrite the code manually to perform the same optimization. So, it's not exactly the same code, but using only the features of the go programming language, this code now performs as well as the equivalent c code on my mac.