### PR TITLE
Use stackalloc in C#

### DIFF
--- a/loops/csharp/code.cs
+++ b/loops/csharp/code.cs
@@ -2,7 +2,7 @@
 var r = Random.Shared.Next(10_000);
 
 //Use span instead of array
-Span<int> a = new int[10_000];
+Span<int> a = stackalloc int[10_000];
 
 //using a.Length instead of 10_000 constant should give the compiler better optimization hints
 for (var i = 0; i < a.Length; i++)


### PR DESCRIPTION
Use stackalloc instead of new.

Would only be fair since that's what the C sample does!  🤓 


Is it faster? probably a few nanonseconds.