### PR TITLE
Added Kotlin Native target

### DIFF
--- a/clean.sh
+++ b/clean.sh
@@ -3,6 +3,7 @@ rm go/code
 rm jvm/code.class
 rm -r rust/target
 rm -rf kotlin/code.jar
+rm kotlin/code.kexe
 rm dart/code
 rm -rf inko/build inko/code
 rm nim/code

--- a/compile.sh
+++ b/compile.sh
@@ -7,7 +7,7 @@ native-image -O3 jvm.code
 RUSTFLAGS="-Zlocation-detail=none" cargo +nightly build --manifest-path rust/Cargo.toml --release
 cargo build --manifest-path rust/Cargo.toml --release
 kotlinc -include-runtime kotlin/code.kt -d kotlin/code.jar
-#kotlinc-native -include-runtime kotlin/code.kt -d kotlin/code
+kotlinc-native kotlin/code.kt -o kotlin/code -opt
 dart compile exe dart/code.dart -o dart/code --target-os=macos
 cd inko && inko build --opt=aggressive code.inko -o code && cd ..
 nim c -d:danger --opt:speed nim/code.nim

--- a/run.sh
+++ b/run.sh
@@ -6,7 +6,8 @@ function run {
 
 run "Dart" "./dart/code 40"
 run "Objective-C" "./objc/code 40"
-run "Kotlin" "java -jar kotlin/code.jar 40"
+run "Kotlin JVM" "java -jar kotlin/code.jar 40"
+run "Kotlin Native" "./kotlin/code.kexe 40"
 run "C" "./c/code 40"
 run "Rust" "./rust/target/release/code 40"
 run "Node" "node ./js/code.js 40" 


### PR DESCRIPTION
Related to #142 but simplified with just the addition of [Kotlin Native](https://kotlinlang.org/docs/native-overview.html) target, using the same code for both Kotlin targets (JVM and Native).

Instructions for installing Kotlin Native compiler `kotlinc-native`:

- macOS via [Homebrew](https://brew.sh): `brew install --cask kotlin-native`
- Linux and Windows: [docs](https://kotlinlang.org/docs/native-command-line-compiler.html)