### PR TITLE
Go: change rand func to Int31n

### DIFF
--- a/loops/go/code.go
+++ b/loops/go/code.go
@@ -10,7 +10,7 @@ func main() {
   input, e := strconv.Atoi(os.Args[1]) // Get an input number from the command line
   if e != nil { panic(e) }
   u := int32(input)
-  r := int32(rand.Intn(10000))           // Get a random number 0 <= r < 10k
+  r := rand.Int31n(10000)              // Get a random number 0 <= r < 10k
   var a[10000]int32                      // Array of 10k elements initialized to 0
   for i := int32(0); i < 10000; i++ {         // 10k outer loop iterations
     for j := int32(0); j < 100000; j++ {      // 100k inner loop iterations, per outer loop iteration


### PR DESCRIPTION
Int31n returns, as an int32, a non-negative pseudo-random number in the half-open interval [0,n).

This change will avoid the  unnecessary casting (generating a low i64 integer number then casting to i32)