### PR TITLE
fix(Python fibonacci): adding cache to speed up the calculation

### DIFF
--- a/fibonacci/py/code.py
+++ b/fibonacci/py/code.py
@@ -1,17 +1,22 @@
 import sys
+from functools import cache
 
+
+@cache
 def fibonacci(n):
-  if (n == 0):
-    return 0
-  if (n == 1):
-    return 1
-  return fibonacci(n-1) + fibonacci(n-2)
+    if n == 0:
+        return 0
+    if n == 1:
+        return 1
+    return fibonacci(n - 1) + fibonacci(n - 2)
+
 
 def main():
     u = int(sys.argv[1])
     r = 0
     for i in range(1, u):
-      r += fibonacci(i)
+        r += fibonacci(i)
     print(r)
+
 
 main()


### PR DESCRIPTION
(also: code formatting)

Python is well-known for not being optimized for recursions like this. 

A "hack" is to use the builtin `functools.cache` that speeds up this kind of thing significantly. I _think_ this is the way the Pythonistas would write a function like this.

I understand that this is not the intention of the benchmark, but wanted to highlight that you wouldn't write Python in that kind of way because of the limitations of it 😄 