### PR TITLE
Interchange loops for efficiency in C "loops"

### DIFF
--- a/loops/c/code.c
+++ b/loops/c/code.c
@@ -7,12 +7,14 @@ int main (int argc, char** argv) {
   int u = atoi(argv[1]);               // Get an input number from the command line
   srand(time(NULL));                   // FIX random seed
   int r = rand() % 10000;              // Get a random integer 0 <= r < 10k
-  int32_t a[10000] = {0};              // Array of 10k elements initialized to 0
-  for (int i = 0; i < 10000; i++) {    // 10k outer loop iterations
-    for (int j = 0; j < 100000; j++) { // 100k inner loop iterations, per outer loop iteration
-      a[i] = a[i] + j%u;               // Simple sum
+  int32_t a[10000];                    // Array of 10k elements initialized to a random value
+  for (int i = 0; i < 10000; i++) {
+    a[i] = r;
+  }
+  for (int j = 0; j < 100000; j++) {   // 100k outer loop iterations
+    for (int i = 0; i < 10000; i++) {  // 10k inner loop iterations, per outer loop iteration
+      a[i] += j%u;                     // Simple sum
     }
-    a[i] += r;                         // Add a random value to each element in array
   }
   printf("%d\n", a[r]);                // Print out a single element from the array
 }


### PR DESCRIPTION
These changes demonstrate a significant speed-up in the C loops benchmark while calculating otherwise identical results.

'a' can be initialized to r instead of 0. This avoids an unnecessary initialization and allows the 'i' and 'j' loops to be interchanged. And with the loops interchanged, the relatively expensive "j%u" operation can be more readily optimized by the compiler. In source code, there are still 1 billion "+= j%u" operations, same as the current benchmark.

I don't necessarily expect this pull request to be accepted because you might deliberately want the benchmark implementations to be "identical". But if you're open to a faster solution to the same problem, here it is!

Thanks!