### PR TITLE
Significantly faster C benchmark, minimal change

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -1,4 +1,4 @@
-clang -O3 c/code.c -o c/code
+clang -march=native -O3 -Ofast -o c/code c/code.c
 clang++ -std=c++23 -march=native -O3 -Ofast -o cpp/code cpp/code.cpp
 go build -ldflags "-s -w" -o go/code go/code.go
 javac jvm/code.java

--- a/loops/c/code.c
+++ b/loops/c/code.c
@@ -8,9 +8,13 @@ int main (int argc, char** argv) {
   srand(time(NULL));                   // FIX random seed
   int r = rand() % 10000;              // Get a random integer 0 <= r < 10k
   int32_t a[10000] = {0};              // Array of 10k elements initialized to 0
+  static int32_t jmodu[100000];        // Array of 100k elements
+  for (int j = 0; j < 100000; j++) {   // Precompute 'j % u' values
+    jmodu[j] = j % u;
+  }
   for (int i = 0; i < 10000; i++) {    // 10k outer loop iterations
     for (int j = 0; j < 100000; j++) { // 100k inner loop iterations, per outer loop iteration
-      a[i] = a[i] + j%u;               // Simple sum
+      a[i] += jmodu[j];                // Simple sum
     }
     a[i] += r;                         // Add a random value to each element in array
   }


### PR DESCRIPTION
I've seen other pull requests that propose much larger changes than this to their respective benchmark. There is one for C implemented using AVX2 SIMD intrinsics. Another for Python restructures the loops and makes Numpy library calls, etc, to allow for vectorization.

I share this implementation because, as you can see, it makes no actual changes to the algorithm itself. By simply pre-computing "j%u" in advance, the benchmark can run **much** faster and SIMD auto-vectorization is now trivial for the compiler (no platform-specific SIMD intrinsics required).

32 times faster with AVX2 enabled (clang -mavx2)
70 times faster with AVX512 (clang -mavx512f)
10 times faster than the other PR using AVX2 SIMD intrinsics

As with my other PR that I closed, I don't necessarily expect this to be accepted because I understand the intent for "the same" implementations between languages. But I'd venture to say that this is the fastest C benchmark that's closest to the original. So, I share it.

Regards.