### PR TITLE
Add levensthtein for Clojure and Babashka (and Java for good measure)

### DIFF
--- a/levenshtein/bb/code.clj
+++ b/levenshtein/bb/code.clj
@@ -1,0 +1,54 @@
+(defn levenshtein-distance [s1 s2]
+  (let [m (count s1)
+        n (count s2)
+        ;; Create a matrix to store distances
+        matrix (vec (map vec (repeat (inc m) (repeat (inc n) 0))))]
+    ;; Initialize first row and column
+    (loop [i 0
+           matrix (assoc-in matrix [0 0] 0)]
+      (if (< i (inc m))
+        (recur (inc i) (assoc-in matrix [i 0] i))
+        (loop [j 0
+               matrix matrix]
+          (if (< j (inc n))
+            (recur (inc j) (assoc-in matrix [0 j] j))
+            ;; Compute Levenshtein distance
+            (loop [i 1
+                   matrix matrix]
+              (if (<= i m)
+                (recur (inc i)
+                       (loop [j 1
+                              matrix matrix]
+                         (if (<= j n)
+                           (let [cost (if (= (nth s1 (dec i)) (nth s2 (dec j))) 0 1)]
+                             (recur (inc j)
+                                    (assoc-in matrix [i j]
+                                              (min
+                                               (inc (get-in matrix [(dec i) j]))              ;; Deletion
+                                               (inc (get-in matrix [i (dec j)]))              ;; Insertion
+                                               (+ (get-in matrix [(dec i) (dec j)]) cost))))) ;; Substitution
+                           matrix)))
+                (get-in matrix [m n])))))))))
+
+(defn main [& args]
+  (let [strings (vec args)
+        n (count strings)
+        distances (for [i (range n)
+                        j (range n)
+                        :when (not= i j)]
+                    (levenshtein-distance (nth strings i) (nth strings j)))
+        min-distance (apply min distances)]
+    (println "times:" (* n (dec n)))
+    (println "min_distance:" min-distance)))
+
+(when (= *file* (System/getProperty "babashka.file"))
+  (apply main *command-line-args*))
+
+(comment
+  (time
+   (main "abcde" "abdef" "ghijk" "gjkl" "mno" "pqr" "stu" "vwx" "yz" "banana" "oranges"))
+  ;; times: 110
+  ;; min_distance: 2
+  ;; "Elapsed time: 1.56575 msecs"
+  :rcf)
+

--- a/levenshtein/clojure/code.clj
+++ b/levenshtein/clojure/code.clj
@@ -1,0 +1,34 @@
+(ns code
+  (:gen-class))
+
+(set! *unchecked-math* :warn-on-boxed)
+
+(defn levenshtein-distance ^long [^String s1 ^String s2]
+  (let [m (int (count s1))
+        n (int (count s2))
+        matrix (long-array (* (inc m) (inc n)))]
+    (dotimes [i (inc m)]
+      (aset matrix (* i (inc n)) i))
+    (dotimes [j (inc n)]
+      (aset matrix j j))
+    (dotimes [i m]
+      (dotimes [j n]
+        (let [cost (if (= (.charAt s1 i) (.charAt s2 j)) 0 1)
+              del (inc (aget matrix (+ (* i (inc n)) (inc j))))
+              ins (inc (aget matrix (+ (* (inc i) (inc n)) j)))
+              sub (+ (aget matrix (+ (* i (inc n)) j)) cost)
+              idx (+ (* (inc i) (inc n)) (inc j))
+              v (min del (min ins sub))]
+          (aset matrix idx v))))
+    (aget matrix (+ (* m (inc n)) n))))
+
+(defn -main [& args]
+  (let [strings (vec args)
+        n (count strings)
+        distances (for [i (range n)
+                        j (range n)
+                        :when (not= i j)]
+                    (levenshtein-distance (nth strings i) (nth strings j)))
+        min-distance (apply min distances)]
+    (println "times:" (* n (dec n)))
+    (println "min_distance:" min-distance)))

--- a/levenshtein/jvm/code.java
+++ b/levenshtein/jvm/code.java
@@ -1,0 +1,58 @@
+package jvm;
+
+public class code {
+
+    public static long levenshteinDistance(String s1, String s2) {
+        int m = s1.length();
+        int n = s2.length();
+        long[] matrix = new long[(m + 1) * (n + 1)];
+
+        // Initialize first row and column
+        for (int i = 1; i <= m; i++) {
+            matrix[i * (n + 1)] = i;
+        }
+        for (int j = 1; j <= n; j++) {
+            matrix[j] = j;
+        }
+
+        // Compute Levenshtein distance
+        for (int i = 0; i < m; i++) {
+            for (int j = 0; j < n; j++) {
+                long cost = (s1.charAt(i) == s2.charAt(j)) ? 0 : 1;
+                long del = matrix[i * (n + 1) + (j + 1)] + 1;
+                long ins = matrix[(i + 1) * (n + 1) + j] + 1;
+                long sub = matrix[i * (n + 1) + j] + cost;
+                matrix[(i + 1) * (n + 1) + (j + 1)] = Math.min(del, Math.min(ins, sub));
+            }
+        }
+
+        return matrix[m * (n + 1) + n];
+    }
+
+    public static void main(String[] args) {
+        if (args.length < 2) {
+            System.out.println("Usage: java jvm.code <string1> <string2> ...");
+            return;
+        }
+
+        long minDistance = -1;
+        int times = 0;
+        for (int i = 0; i < args.length - 1; i++) {
+            for (int j = 0; j < args.length - 1; j++) {
+                if (i != j) {
+                    long distance = levenshteinDistance(args[i], args[j]);
+                    if (minDistance == -1 || minDistance > distance) {
+                        minDistance = distance;
+                    }
+                    times++;
+                }
+            }
+        }
+
+        // The only output from the program should be the times (number of comparisons)
+        // and min distance calculated of all comparisons. Two total lines of output,
+        // formatted exactly like this.
+        System.out.println("times: " + times);
+        System.out.println("min_distance: " + minDistance);
+    }
+}

--- a/run.sh
+++ b/run.sh
@@ -57,6 +57,7 @@ run "Clojure" "java -cp clojure/classes:$(clojure -Spath)" "./clojure/code"
 run "Babashka" "bb -cp clojure -m" "./babashka/code"
 run "COBOL" "" "./cobol/main"
 run "Octave" "octave ./octave/code.m 40"
+run "Babashka" "bb" "bb/code.clj"
 #run "F# AOT" "./fsharp/code-aot/code"
 #run "C# AOT" "./csharp/code-aot/code"
 #run "Haxe JVM" "java -jar haxe/code.jar" # was getting errors running `haxelib install hxjava`


### PR DESCRIPTION
The Clojure and Java solutions are not as close to C's as with the other benchmarks, but still decent.

**Java**:
```
Evaluation count : 66 in 6 samples of 11 calls.
             Execution time mean : 10.133643 ms
    Execution time std-deviation : 721.632889 µs
   Execution time lower quantile : 9.165525 ms ( 2.5%)
   Execution time upper quantile : 10.955189 ms (97.5%)
                   Overhead used : 1.295061 ns
```
**Clojure**:
```
Evaluation count : 60 in 6 samples of 10 calls.
             Execution time mean : 10.776057 ms
    Execution time std-deviation : 670.658990 µs
   Execution time lower quantile : 10.254974 ms ( 2.5%)
   Execution time upper quantile : 11.682582 ms (97.5%)
                   Overhead used : 1.295061 ns
```

It's too few runs to draw any conclusions about the difference between these two. But we can assume that there is a small overhead for Clojure in about the amount indicated.

## Start times again

Of course, with this benchmark it gets even more obvious that we need to do something to mitigate for the start times of the languages. Because running this with hyperfine:

```
Benchmarking C
Benchmark 1:  ./c/code aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbbb
  Time (mean ± σ):       5.6 ms ±   0.1 ms    [User: 4.2 ms, System: 1.0 ms]
  Range (min … max):     5.5 ms …   5.7 ms    3 runs
 

Benchmarking Java
Benchmark 1: java jvm.code aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa bbbbbbbbbbbbbbb
  Time (mean ± σ):      72.5 ms ±   0.7 ms    [User: 45.5 ms, System: 22.3 ms]
  Range (min … max):    71.8 ms …  73.2 ms    3 runs
 

Benchmarking Clojure
Benchmark 1: java -cp clojure/classes:src:/Users/pez/.m2/repository/org/clojure/clojure/1.12.0/cloju
  Time (mean ± σ):     302.8 ms ±   5.8 ms    [User: 464.0 ms, System: 47.2 ms]
  Range (min … max):   298.5 ms … 309.4 ms    3 runs
 

Benchmarking Babashka
Benchmark 1: bb bb/code.clj aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa bbbbbbbbbbbbbb
  Time (mean ± σ):      2.018 s ±  0.010 s    [User: 1.991 s, System: 0.024 s]
  Range (min … max):    2.011 s …  2.029 s    3 runs 
```

So while Java and Clojure may be some 2-3 times slower than C on this algorithm. The benchmark makes it look more like 10X and 50X, respectively... Related:

* #220
* #231 

## The new `run.sh` needs attention

While adding this I noticed that the new `run.sh` fails to check file existence for Java and Clojure (and probably a lot of other languages too). It can't be assumed that the argument to the command for running the program is a file. To solve it so that I could run the benchmark for the languages I added I used this:

```sh
function run {
  if [ -f ${2} ]; then
    echo ""
    echo "Benchmarking $1"
    input=`cat input.txt`
    hyperfine -i --shell=none --runs 3 --warmup 2 "${3} ${4} ${input}" | cut -c1-100
  fi
}

run "C" "./c/code" "" "./c/code"
run "Java" "./jvm/code.class" "java" "jvm.code"
run "Clojure" "./clojure/code.clj" "java -cp clojure/classes:$(clojure -Spath)" "code"
run "Babashka" "bb/code.clj" "bb" "bb/code.clj"
```

So, introducing the file to check for as the second parameter to `run`. 

## Separate Babashka and Clojure code

Note that this has separate code for Clojure and Babashka, so this PR is related:

* #223