### PR TITLE
levenshtein: Zig: use memcopy and avoid using allocators

### DIFF
--- a/levenshtein/zig/code.zig
+++ b/levenshtein/zig/code.zig
@@ -3,12 +3,7 @@ const std = @import("std");
 /// Calculates the Levenshtein distance between two strings using Wagner-Fischer algorithm
 /// Space Complexity: O(min(m,n)) - only uses two arrays instead of full matrix
 /// Time Complexity: O(m*n) where m and n are the lengths of the input strings
-fn levenshteinDistance(allocator: std.mem.Allocator, s1: []const u8, s2: []const u8) !usize {
-    // Early termination checks
-    if (std.mem.eql(u8, s1, s2)) return 0;
-    if (s1.len == 0) return s2.len;
-    if (s2.len == 0) return s1.len;
-
+fn levenshteinDistance(s1: []const u8, s2: []const u8) usize {
     // Make s1 the shorter string for space optimization
     const str1 = if (s1.len > s2.len) s2 else s1;
     const str2 = if (s1.len > s2.len) s1 else s2;
@@ -17,14 +12,12 @@ fn levenshteinDistance(allocator: std.mem.Allocator, s1: []const u8, s2: []const
     const n = str2.len;
 
     // Use two arrays instead of full matrix for space optimization
-    var prev_row = try allocator.alloc(usize, m + 1);
-    defer allocator.free(prev_row);
-    var curr_row = try allocator.alloc(usize, m + 1);
-    defer allocator.free(curr_row);
+    var prev_row: [256]usize = undefined;
+    var curr_row: [256]usize = undefined;
 
     // Initialize first row
-    for (prev_row, 0..) |*cell, i| {
-        cell.* = i;
+    for (0..m + 1) |i| {
+        prev_row[i] = i;
     }
 
     // Main computation loop
@@ -47,9 +40,7 @@ fn levenshteinDistance(allocator: std.mem.Allocator, s1: []const u8, s2: []const
         }
 
         // Swap rows
-        const temp = prev_row;
-        prev_row = curr_row;
-        curr_row = temp;
+        @memcpy(prev_row[0..m + 1], curr_row[0..m + 1]);
     }
 
     return prev_row[m];
@@ -78,7 +69,7 @@ pub fn main() !void {
         var j: usize = 1;
         while (j < args.len) : (j += 1) {
             if (i != j) {
-                const distance = try levenshteinDistance(allocator, args[i], args[j]);
+                const distance = levenshteinDistance(args[i], args[j]);
                 if (min_distance == -1 or distance < @as(usize, @intCast(min_distance))) {
                     min_distance = @as(isize, @intCast(distance));
                 }

--- a/levenshtein/zig/code.zig
+++ b/levenshtein/zig/code.zig
@@ -4,6 +4,11 @@ const std = @import("std");
 /// Space Complexity: O(min(m,n)) - only uses two arrays instead of full matrix
 /// Time Complexity: O(m*n) where m and n are the lengths of the input strings
 fn levenshteinDistance(s1: []const u8, s2: []const u8) usize {
+    // Early termination checks
+    if (std.mem.eql(u8, s1, s2)) return 0;
+    if (s1.len == 0) return s2.len;
+    if (s2.len == 0) return s1.len;
+
     // Make s1 the shorter string for space optimization
     const str1 = if (s1.len > s2.len) s2 else s1;
     const str2 = if (s1.len > s2.len) s1 else s2;


### PR DESCRIPTION
The Levenshtein benchmark graphics made me suspicious something was up with the Zig implementation of the new reference. My understanding of Zig performance is that it is generally at C level or faster. Indeed, by avoiding try/catch allocators and using memcopy instead of assigning via a swap variable I could get 5X faster and almost where C is. I think that someone who knows Zig better than I do (this is the first Zig I've ever touched) can find more performance.

## Before

```
Benchmarking Zig
Benchmark 1:  ./zig/code aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa...
  Time (mean ± σ):      50.8 ms ±  12.6 ms    [User: 10.2 ms, System: 40.2 ms]
  Range (min … max):    37.5 ms …  73.3 ms    7 runs
 

Benchmarking C
Benchmark 1:  ./c/code aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa...
  Time (mean ± σ):       8.6 ms ±   1.0 ms    [User: 6.8 ms, System: 1.4 ms]
  Range (min … max):     7.7 ms …  10.7 ms    7 runs
 

Benchmarking Rust
Benchmark 1:  ./rust/target/release/code aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa...
  Time (mean ± σ):      11.7 ms ±   0.3 ms    [User: 10.2 ms, System: 1.1 ms]
  Range (min … max):    11.2 ms …  11.9 ms    7 runs
```

## After

```
Benchmarking Zig
Benchmark 1:  ./zig/code aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa...
  Time (mean ± σ):       9.6 ms ±   0.2 ms    [User: 8.3 ms, System: 1.0 ms]
  Range (min … max):     9.4 ms …  10.1 ms    7 runs
 

Benchmarking C
Benchmark 1:  ./c/code aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa...
  Time (mean ± σ):       8.0 ms ±   0.3 ms    [User: 6.6 ms, System: 1.1 ms]
  Range (min … max):     7.7 ms …   8.7 ms    7 runs
 

Benchmarking Rust
Benchmark 1:  ./rust/target/release/code aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa...
  Time (mean ± σ):      11.4 ms ±   0.3 ms    [User: 10.1 ms, System: 1.0 ms]
  Range (min … max):    11.0 ms …  11.8 ms    7 runs
```