### PR TITLE
Dart improvements to Levenshtein challenge, roughly 47% faster

### DIFF
--- a/levenshtein/dart/code.dart
+++ b/levenshtein/dart/code.dart
@@ -4,28 +4,28 @@ int levenshteinDistance(String word1, String word2) {
   final m = word1.length;
   final n = word2.length;
   // Create a matrix to store distances
-  var matrix = List.generate(m+1, (i) => List.generate(n+1, (j) => 0));
+  var matrix = List.generate(m + 1, (i) => List.generate(n + 1, (j) => 0));
 
-  // Initialize first row and column 
+  // Initialize first row and column
   for (int i = 1; i <= m; i++) {
-      matrix[i][0] = i;
+    matrix[i][0] = i;
   }
   for (int j = 1; j <= n; j++) {
-      matrix[0][j] = j;
+    matrix[0][j] = j;
   }
-  
+
   // Compute Levenshtein distance
   for (int i = 1; i <= m; i++) {
-      for (int j = 1; j <= n; j++) {
-        int cost = word1[i-1] == word2[j-1]? 0:1;
-        matrix[i][j] = min(
-            min(
-                matrix[i-1][j] + 1, // Deletion
-                matrix[i][j-1] + 1  // Insertion
-            ),
-            matrix[i-1][j-1] + cost // Substitution
-        );
-      }
+    for (int j = 1; j <= n; j++) {
+      int cost = word1[i - 1] == word2[j - 1] ? 0 : 1;
+      matrix[i][j] = min(
+          min(
+              matrix[i - 1][j] + 1, // Deletion
+              matrix[i][j - 1] + 1 // Insertion
+              ),
+          matrix[i - 1][j - 1] + cost // Substitution
+          );
+    }
   }
   return matrix[m][n];
 }
@@ -40,15 +40,15 @@ void main(List<String> args) {
   int times = 0;
   // Compare each pair of arguments exactly once
   for (int i = 0; i < args.length; i++) {
-      for (int j = i+1; j < args.length; j++) {
-        if (i != j) {
-            int distance = levenshteinDistance(args[i], args[j]);
-            if (minDistance == -1 || distance < minDistance ) {
-                minDistance = distance;
-            }
-            times++;
+    for (int j = i + 1; j < args.length; j++) {
+      if (i != j) {
+        int distance = levenshteinDistance(args[i], args[j]);
+        if (minDistance == -1 || distance < minDistance) {
+          minDistance = distance;
         }
+        times++;
       }
+    }
   }
 
   // The only output from the program should be the times (number of comparisons)

--- a/levenshtein/dart/code.dart
+++ b/levenshtein/dart/code.dart
@@ -21,15 +21,17 @@ int levenshteinDistance(String word1, String word2) {
 
   // Compute Levenshtein distance
   for (int i = 1; i <= m; i++) {
+    final row = matrix[i];
+    final previousRow = matrix[i - 1];
     for (int j = 1; j <= n; j++) {
       int cost = word1[i - 1] == word2[j - 1] ? 0 : 1;
-      matrix[i][j] = min(
-          min(
-              matrix[i - 1][j] + 1, // Deletion
-              matrix[i][j - 1] + 1 // Insertion
-              ),
-          matrix[i - 1][j - 1] + cost // Substitution
-          );
+      row[j] = min(
+        min(
+          previousRow[j] + 1, // Deletion
+          row[j - 1] + 1, // Insertion
+        ),
+        previousRow[j - 1] + cost, // Substitution
+      );
     }
   }
   return matrix[m][n];

--- a/levenshtein/dart/code.dart
+++ b/levenshtein/dart/code.dart
@@ -8,6 +8,7 @@ int levenshteinDistance(String word1, String word2) {
   var matrix = List.generate(
     m + 1,
     (i) => Int16List(n + 1),
+    growable: false,
   );
 
   // Initialize first row and column

--- a/levenshtein/dart/code.dart
+++ b/levenshtein/dart/code.dart
@@ -1,10 +1,14 @@
 import 'dart:math';
+import 'dart:typed_data';
 
 int levenshteinDistance(String word1, String word2) {
   final m = word1.length;
   final n = word2.length;
   // Create a matrix to store distances
-  var matrix = List.generate(m + 1, (i) => List.generate(n + 1, (j) => 0));
+  var matrix = List.generate(
+    m + 1,
+    (i) => Int16List(n + 1),
+  );
 
   // Initialize first row and column
   for (int i = 1; i <= m; i++) {


### PR DESCRIPTION
This PR includes changes to the Levenshtein challenge, Dart solution.

The individual commits describe the steps:

* 6c9aeb6 Fix Dart code with standard dart formatting tool
* fc18e35 Use Int16List for inner int list
* 291bb16 Make outer list not growable
* 8f2059e Extract row and prev row in levenshtein dist calculation

The majority of the improvements are due to the inner list using [`Int16List`](https://api.dart.dev/stable/2.15.1/dart-typed_data/Int16List-class.html), though the other two commits (outer list not growable, and extracting the row into its own variable) also consistently performed a couple of % better.

I also formatted the code. In Dart, it's standard to use the [built-in Dart tooling for formatting](https://dart.dev/tools/dart-format) Dart source code.

On my machine, these changes make the Dart code roughly the same speed as Swift.

Languages that were previously faster, but are now (with my changes) slower than Dart: Java, LuaJIT, C#, Bun (using [this tweet](https://x.com/BenjDicken/status/1869412072318283783) as a reference).