### PR TITLE
stop using coursier launcher for scala artifacts

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -27,7 +27,7 @@ compile 'nim' 'nim -d:release --threads:off --stackTrace:off --lineTrace:off --o
 compile 'sbcl' 'sbcl --noinform --non-interactive --load "common-lisp/code.lisp" --build'
 compile 'fpc' 'fpc -O3 fpc/code.pas'
 compile 'crystal' 'crystal build -o crystal/code --release crystal/code.cr'
-compile 'scala' 'scala-cli --power package scala/code.scala -f -o scala/code'
+compile 'scala' 'scala-cli --power package --assembly scala/code.scala -f -o scala/code'
 compile 'scala' 'scala-cli --power package --native scala/code.scala -f -o scala/code-native --native-mode release-full'
 compile 'ldc2' 'ldc2 -O3 -release -boundscheck=off -mcpu=native flto=thin d/code.d'
 compile 'odin' 'odin build odin/code.odin -o:speed -file -out:odin/code'


### PR DESCRIPTION
The `scala-cli` command that's being used here for jvm packages builds a jar that includes just three things - user application classes, [coursier](https://get-coursier.io/) launcher classes and a manifest of all dependencies. This is done because coursier is able to resolve and fetch all dependencies on start of the application and allows for two things 
a) smaller app packages
b) avoids all the trouble that comes with building fat jars, the deps jars are resolved as full, separate jars and put onto the classpath as they are published

In many cases what you really want **is** a fat jar / assembly jar which contains all dependencies - scala stdlib and other libraries. This is one of these cases as what you are measuring right now is not how fast Scala is as a language, it's how fast Coursier is able to fetch and assemble the classpath dynamically and run the program on a separate classloader.

Scala-cli has the ability to build fat jars that have a runner script prepended by adding `--assembly` (it's executable, no need to run it with `java -jar`). 

This PR adds the `--assembly` flag for Scala JVM.