### PR TITLE
Change integer type to be similar to C code

### DIFF
--- a/loops/py/code.py
+++ b/loops/py/code.py
@@ -1,13 +1,15 @@
 import sys
-import random
+import numpy as np
 
 
 def main():
-    u = int(sys.argv[1])  # Get an input number from the command line
-    r = random.randint(0, 10000)  # Get a random number 0 <= r < 10k
-    a = [0] * 10000  # Array of 10k elements initialized to 0
-    for i in range(10000):  # 10k outer loop iterations
-        for j in range(100000):  # 100k inner loop iterations, per outer loop iteration
+    cnt = np.int32(sys.argv[1])
+    u = np.int32(cnt)  # Get an input number from the command line
+    r = np.random.randint(0, 10000, dtype=np.int32)  # Get a random number 0 <= r < 10k
+    a = np.zeros(10000, dtype=np.int32)  # Array of 10k elements initialized to 0
+
+    for i in np.arange(10000, dtype=np.int32):  # 10k outer loop iterations
+        for j in np.arange(10000, dtype=np.int32):  # 100k inner loop iterations, per outer loop iteration
             a[i] += j % u  # Simple sum
         a[i] += r  # Add a random value to each element in array
     print(a[r])  # Print out a single element from the array


### PR DESCRIPTION
I have:

* [x] Read the project [README](../README.md), including the [benchmark descriptions](../README.md#available-benchmarks)

## Description of changes

* fix performance issue with advanced default integer type in Python and replace by C int32_t alternative from numpy
    * more details about the type difference here: https://stackoverflow.com/questions/69936882/question-on-python-treatment-of-numpy-int32-vs-int/69937778#69937778
   * in a few words, python int type by default don't have limit(not 32- or 64-bit type), but can store unlimited max and min values what makes logic much more complicated.
* It's done to make python code closer to C reference implementation
