### PR TITLE
Ignore Scala build things

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@ Cargo.lock
 **/cobol/main
 **/js/bun
 *.iprof
+.scala-build
+*/scala/code-native
+*/scala/code.js
+levenshtein.mod


### PR DESCRIPTION
I have:

* [x] Read the project [README](../README.md), including the [benchmark descriptions](../README.md#available-benchmarks)

## Description of changes

Scala produces a lot of build artifacts!