### PR TITLE
Strip ansi escapes

### DIFF
--- a/loops/check.sh
+++ b/loops/check.sh
@@ -1,7 +1,7 @@
 expected_min=1950000
 expected_max=1959999
 
-output="${*}"
+output=$(echo "${*}" | sed 's/\x1b\[[0-9;]*m//g')
 
 if [ "$output" -ge "$expected_min" ] && [ "$output" -le "$expected_max" ]; then
   echo "Check passed"


### PR DESCRIPTION
* [x] Read the project [README](../README.md), including the [benchmark descriptions](../README.md#available-benchmarks)

## Description of changes

Decided to accept that some executables will probably ansi-escape their output, so stripping escapes in `check.sh`

* Fixes: #297


