### PR TITLE
Check for non-zero exit value

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -4,7 +4,7 @@ function compile {
     echo "Compiling $1"
     ${2} 2> /dev/null
     result=$?
-    if [ $result -eq 1 ]; then
+    if [ $result -ne 0 ]; then
         echo "Failed to compile ${1} with command: ${2}"
     fi
   fi


### PR DESCRIPTION
I have:

* [x] Read the project [README](../README.md), including the [benchmark descriptions](../README.md#available-benchmarks)

## Description of changes

We were checking for if the exit value was 1 to determine problems, but there can be many non-zero values.

* Fixes #307

