### PR TITLE
Strip ansi from all check.sh scripts

### DIFF
--- a/fibonacci/check.sh
+++ b/fibonacci/check.sh
@@ -1,6 +1,6 @@
 expected_output="165580140"
 
-trimmed_output=$(echo "${*}" | awk '{$1=$1};1')
+trimmed_output=$(echo "${*}" | sed 's/\x1b\[[0-9;]*m//g' | awk '{$1=$1};1')
 
 if [ "${trimmed_output}" == "${expected_output}" ]; then
   echo "Check passed"

--- a/hello-world/check.sh
+++ b/hello-world/check.sh
@@ -1,6 +1,6 @@
 expected_output="hello, world!"
 
-trimmed_output=$(echo "${*}" | awk '{$1=$1};1' | tr '[:upper:]' '[:lower:]')
+trimmed_output=$(echo "${*}" | sed 's/\x1b\[[0-9;]*m//g' | awk '{$1=$1};1' | tr '[:upper:]' '[:lower:]')
 
 if [ "${trimmed_output}" == "${expected_output}" ]; then
   echo "Check passed"

--- a/levenshtein/check.sh
+++ b/levenshtein/check.sh
@@ -1,7 +1,7 @@
 expected_output="times: 3906
 min_distance: 7"
 
-trimmed_output=$(echo "${*}" | awk '{$1=$1};1')
+trimmed_output=$(echo "${*}" | sed 's/\x1b\[[0-9;]*m//g' | awk '{$1=$1};1')
 
 if [ "${trimmed_output}" == "${expected_output}" ]; then
   echo "Check passed"


### PR DESCRIPTION
I have:

* [x] Read the project [README](../README.md), including the [benchmark descriptions](../README.md#available-benchmarks)

## Description of changes

Last time around I missed that Bun also outputs ansi highlighted results for **fibonacci**. Now stripping ansi in all benchmark outputs before checking. Thus:

* Fixes #297 for all benchmarks
