### PR TITLE
Fix fortran clipping strings

### DIFF
--- a/levenshtein/fortran/code.f90
+++ b/levenshtein/fortran/code.f90
@@ -90,8 +90,8 @@ program main
     implicit none
     
     integer :: num_args, i, j, distance, min_distance, times
-    character(len=100), allocatable :: args(:)
-    character(len=100) :: arg
+    character(len=300), allocatable :: args(:)
+    character(len=300) :: arg
     
     ! Get command line arguments
     num_args = command_argument_count()


### PR DESCRIPTION
fix fortran clipping strings

<!-- Thanks for helping to improve this project! 🙏 -->

I have:

* [x] Read the project [README](../README.md), including the [benchmark descriptions](../README.md#available-benchmarks)

## Description of changes

<!-- 

Please include a descrition for your change. Things like:

* Why it is done (a problem description)
  If there's an issue describing the problem, please refer it. If your PR is fixing the problem described in the issue, use the _Fixes #<issue-no>_  syntax.
* Why it is done the way you have done it (a solution description)

Please help us understand the changes and the rationale even if we are not experts or even familiar with the particular language you are providing changes for.

If you provide changes to the implementation of one or more language, for one or more benchmark, please include output from benchmark runs, before and after the change.

Thanks again for contributing!
-->

