### PR TITLE
Use gcc for C and g++ for C++

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -11,8 +11,8 @@ function compile {
 }
 
 compile 'c3' 'c3c compile c3/code.c3 -o c3/code'
-compile 'c' 'clang -O3 c/code.c -o c/code'
-compile 'cpp' 'clang++ -std=c++23 -march=native -O3 -Ofast -o cpp/code cpp/code.cpp'
+compile 'c' 'gcc -O3 c/code.c -o c/code'
+compile 'cpp' 'g++ -std=c++23 -march=native -O3 -Ofast -o cpp/code cpp/code.cpp'
 #compile 'go' 'go build -ldflags "-s -w" -o go/code go/code.go'
 go build -ldflags "-s -w" -o go/code go/code.go
 compile 'jvm' 'javac jvm/code.java'

--- a/loops/cpp/code.cpp
+++ b/loops/cpp/code.cpp
@@ -1,9 +1,10 @@
 #include <string>
 #include <random>
 #include <array>
-#include <print>
+#include <iostream>
 #include <cstdint>
 #include <ranges>
+using namespace std;
 
 int main (int argc, char* argv[])
 {
@@ -20,5 +21,5 @@ int main (int argc, char* argv[])
             array[i] += j % mod;                                // Simple sum
         array[i] += picked_number;                              // Add a random value to each element in array
     }
-    std::println("{}", array[picked_number]);                   // Print out a single element from the array
+     cout <<  array[picked_number] << endl;                     // Print out a single element from the array  
 }


### PR DESCRIPTION
I have:

* [x] Read the project [README](../README.md), including the [benchmark descriptions](../README.md#available-benchmarks)

## Description of changes

The main change is about replacing `clang` with `gcc` for the C compile command line, and `clang++` with `g++` for C++.

I also had to change the CPP **loops** code slightly to make it compatible with `g++` (while still compiling cleanly with `clang++`).

On my Mac M4 it seems to maybe hurt performance a tiny bit for the **loops** test, but makes a quite dramatic difference for **fibonacci**, and significant difference for **levenstein**.

### Loops

**clang/clang++**

```
Checking C
Check passed
Benchmarking C
Benchmark 1: ./c/code 40
  Time (mean ± σ):     513.4 ms ±   4.4 ms    [User: 502.3 ms, System: 4.8 ms]
  Range (min … max):   507.7 ms … 521.6 ms    7 runs
 

Checking CPP
Check passed
Benchmarking CPP
Benchmark 1: ./cpp/code 40
  Time (mean ± σ):     515.9 ms ±   5.7 ms    [User: 505.6 ms, System: 4.5 ms]
  Range (min … max):   509.8 ms … 527.6 ms    7 runs
```

**gcc/g++**

```
Checking C
Check passed
Benchmarking C
Benchmark 1: ./c/code 40
  Time (mean ± σ):     523.8 ms ±   3.6 ms    [User: 512.6 ms, System: 6.0 ms]
  Range (min … max):   519.4 ms … 529.6 ms    7 runs
 

Checking CPP
Check passed
Benchmarking CPP
Benchmark 1: ./cpp/code 40
  Time (mean ± σ):     529.7 ms ±   2.5 ms    [User: 517.7 ms, System: 7.2 ms]
  Range (min … max):   525.9 ms … 531.8 ms    7 runs
```


### Naïve Fibonacci

**clang/clang++**

```
Checking C
Check passed
Benchmarking C
Benchmark 1: ./c/code 40
  Time (mean ± σ):     278.7 ms ±   3.1 ms    [User: 272.4 ms, System: 3.1 ms]
  Range (min … max):   274.1 ms … 283.1 ms    7 runs
 

Checking CPP
Check passed
Benchmarking CPP
Benchmark 1: ./cpp/code 40
  Time (mean ± σ):     292.5 ms ±   2.4 ms    [User: 286.3 ms, System: 3.1 ms]
  Range (min … max):   289.8 ms … 296.4 ms    7 runs
 
```

**gcc/g++**

```
Checking C
Check passed
Benchmarking C
Benchmark 1: ./c/code 40
  Time (mean ± σ):     117.0 ms ±   1.5 ms    [User: 113.3 ms, System: 2.4 ms]
  Range (min … max):   115.8 ms … 120.1 ms    7 runs
 

Checking CPP
Check passed
Benchmarking CPP
Benchmark 1: ./cpp/code 40
  Time (mean ± σ):     123.5 ms ±   1.4 ms    [User: 117.2 ms, System: 4.4 ms]
  Range (min … max):   120.9 ms … 124.9 ms    7 runs
```

### Levenshtein

**clang/clang++**

```
Checking C
Check passed
Benchmarking C
Benchmark 1: ./c/code aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ...
ciladucljdamhnafrxyabwuihrusmthypjxormffegjwxioyztsdwqemzjdf ...
  Time (mean ± σ):     455.2 ms ±   2.5 ms    [User: 445.7 ms, System: 5.3 ms]
  Range (min … max):   451.6 ms … 458.4 ms    7 runs


Checking CPP
Check passed
Benchmarking CPP
Benchmark 1: ./cpp/code aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ...
ciladucljdamhnafrxyabwuihrusmthypjxormffegjwxioyztsdwqemzjdf ...
  Time (mean ± σ):     442.5 ms ±   3.0 ms    [User: 432.9 ms, System: 5.3 ms]
  Range (min … max):   439.5 ms … 448.1 ms    7 runs
```

**gcc/g++**

```
Checking C
Check passed
Benchmarking C
Benchmark 1: ./c/code aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ...
ciladucljdamhnafrxyabwuihrusmthypjxormffegjwxioyztsdwqemzjdf ...
  Time (mean ± σ):     352.1 ms ±   3.7 ms    [User: 344.1 ms, System: 3.6 ms]
  Range (min … max):   346.4 ms … 356.9 ms    7 runs
 

Checking CPP
Check passed
Benchmarking CPP
Benchmark 1: ./cpp/code aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ...
ciladucljdamhnafrxyabwuihrusmthypjxormffegjwxioyztsdwqemzjdf ...
  Time (mean ± σ):     354.2 ms ±   3.7 ms    [User: 342.9 ms, System: 6.4 ms]
  Range (min … max):   348.3 ms … 360.2 ms    7 runs
```