### PR TITLE
Objective-C printouts and loops performance

### DIFF
--- a/fibonacci/objc/code.m
+++ b/fibonacci/objc/code.m
@@ -12,5 +12,5 @@ int main(int argc, const char * argv[]) {
   for (int i = 1; i < u; i++) {
     r += fibonacci(i);
   }
-  NSLog(@"%d\n", r);
+  printf("%d\n", r);
 }

--- a/loops/objc/code.m
+++ b/loops/objc/code.m
@@ -1,22 +1,17 @@
 #import <Foundation/Foundation.h> 
   
 int main(int argc, const char * argv[]) { 
-    int u = [[NSString stringWithUTF8String:argv[1]] intValue];
-    int r = arc4random() % 10000;            
+    int u = [[NSString stringWithUTF8String:argv[1]] intValue];  // Get an input number from the command line
+    int r = arc4random() % 10000;                                // Get a random integer 0 <= r < 10k
     
-    NSMutableArray *a = [NSMutableArray arrayWithCapacity:10000];
-    for (int i = 0; i < 10000; i++) {
-        [a addObject: @0];
-    }
-    
-    for (int i = 0; i < 10000; i++) {    
-        for (int j = 0; j < 100000; j++) { 
-            a[i] = @([a[i] intValue] + j % u);
+    int32_t a[10000] = {0};                                      // Array of 10k elements initialized to 0
+    for (int i = 0; i < 10000; i++) {                            // 10k outer loop iterations    
+        for (int j = 0; j < 100000; j++) {                       // 100k inner loop iterations, per outer loop iteration
+            a[i] = a[i] + j % u;                                 // Simple sum
         }
-        a[i] = @([a[i] intValue] + r);
+        a[i] += r;                                               // Add a random value to each element in array
     }
-    NSLog(@"%d\n", [a[r] intValue]);
+    printf("%d\n", a[r]);                                        // Print out a single element from the array
 
     return 0; 
 } 
-


### PR DESCRIPTION
I have:

* [X] Read the project [README](../README.md), including the [benchmark descriptions](../README.md#available-benchmarks)

## Description of changes

I set out to fix the prints from fibonacci and loops, which failed `check.sh`. So that's done, but then the loops performance was really awful, which didn't match my perception about Objective-C at all. Using a C array fixed it. I guess in most ObjC programs `NSMutableArray` is what you go for, unless you are really going to crunch through the array, then you probably pick something more suiting. 😄 


### Loops performance

**Before**

```
Checking Objective-C
Check passed
Benchmarking Objective-C
Benchmark 1: ./objc/code 40
  Time (mean ± σ):     13.329 s ±  0.279 s    [User: 12.921 s, System: 0.088 s]
  Range (min … max):   13.043 s … 13.800 s    7 runs
```

**After**

```
Checking Objective-C
Check passed
Benchmarking Objective-C
Benchmark 1: ./objc/code 40
  Time (mean ± σ):     518.4 ms ±   3.6 ms    [User: 508.3 ms, System: 4.7 ms]
  Range (min … max):   513.1 ms … 522.7 ms    7 runs
``` 