### PR TITLE
Making Rust faster than C with this one simple trick (optimization for levenshtein)

### DIFF
--- a/levenshtein/rust/code.rs
+++ b/levenshtein/rust/code.rs
@@ -38,10 +38,10 @@ fn levenshtein_distance(s1: &str, s2: &str) -> usize {
     curr_row.resize(m + 1, 0);
 
     // Main computation loop
-    for j in 1..=n {
+    for j in 1..n + 1 {
         curr_row[0] = j;
 
-        for i in 1..=m {
+        for i in 1..m + 1 {
             let cost = if s1_bytes[i - 1] == s2_bytes[j - 1] { 0 } else { 1 };
             
             // Calculate minimum of three operations


### PR DESCRIPTION
<!-- Thanks for helping to improve this project! 🙏 -->

I have:

* [x] Read the project [README](../README.md), including the [benchmark descriptions](../README.md#available-benchmarks)

## Description of changes

Replacing the inclusive ranges `1..=n` and `1..=m` by exclusive ranges `1..n + 1` and `1..m + 1` in the Rust version of Levenshtein improves the performance by about 25% on my machine (making it about 3% faster than the C version). The reason for that is that the implementation of inclusive ranges accommodates for the fact that the upper bound might be the largest representable integer (e.g. `1..=usize::MAX`) by adding additional code that is executed in every iteration of the loop, which might also prevent certain compiler optimizations from running, making the performance even worse.