### PR TITLE
Fix rust like c for Levenshtein

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "rust-analyzer.linkedProjects": [
+        "levenshtein/rust/Cargo.toml",
+        "levenshtein/rust/code.rs"
+    ]
+}

--- a/compile.sh
+++ b/compile.sh
@@ -2,10 +2,10 @@ function compile {
   if [ -d ${1} ]; then
     echo ""
     echo "Compiling $1"
-    ${2} 2> /dev/null
+    ${2} 2>/dev/null
     result=$?
     if [ $result -ne 0 ]; then
-        echo "Failed to compile ${1} with command: ${2}"
+      echo "Failed to compile ${1} with command: ${2}"
     fi
   fi
 }
@@ -19,8 +19,7 @@ hare build -R -o hare/code hare/code.ha
 compile 'jvm' 'javac jvm/code.java'
 compile 'js' 'bun build --bytecode --compile js/code.js --outfile js/bun'
 # The compile function can't cope with the java-native-image compile
-(cd java-native-image && native-image -cp .. -O3 --pgo-instrument -march=native jvm.code  && ./jvm.code $(cat input.txt) && native-image -cp .. -O3 --pgo -march=native jvm.code -o code)
-compile 'rust' 'RUSTFLAGS="-Zlocation-detail=none" cargo +nightly build --manifest-path rust/Cargo.toml --release'
+(cd java-native-image && native-image -cp .. -O3 --pgo-instrument -march=native jvm.code && ./jvm.code $(cat input.txt) && native-image -cp .. -O3 --pgo -march=native jvm.code -o code)
 compile 'rust' 'cargo build --manifest-path rust/Cargo.toml --release'
 compile 'kotlin' 'kotlinc -include-runtime kotlin/code.kt -d kotlin/code.jar'
 compile 'kotlin' 'kotlinc-native kotlin/code.kt -o kotlin/code -opt'

--- a/levenshtein/rust/code.rs
+++ b/levenshtein/rust/code.rs
@@ -29,13 +29,9 @@ fn levenshtein_distance(s1: &[u8], s2: &[u8]) -> usize {
             };
 
             // Calculate minimum of three operations
-            curr_row[i] = std::cmp::min(
-                std::cmp::min(
-                    prev_row[i] + 1,     // deletion
-                    curr_row[i - 1] + 1, // insertion
-                ),
-                prev_row[i - 1] + cost, // substitution
-            );
+            curr_row[i] = (prev_row[i] + 1) // deletion
+                .min(curr_row[i - 1] + 1) // insertion
+                .min(prev_row[i - 1] + cost); // substitution
         }
 
         // Swap rows

--- a/levenshtein/rust/code.rs
+++ b/levenshtein/rust/code.rs
@@ -3,7 +3,7 @@ use std::env;
 /// Calculates the Levenshtein distance between two strings using Wagner-Fischer algorithm
 /// Space Complexity: O(min(m,n)) - only uses two rows instead of full matrix
 /// Time Complexity: O(m*n) where m and n are the lengths of the input strings
-fn levenshtein_distance(s1: &[u8], s2: &[u8]) -> usize {
+fn levenshtein_distance(s1: &[u8], s2: &[u8]) -> u32 {
     let (s1_bytes, s2_bytes) = if s1.len() > s2.len() {
         (s2, s1)
     } else {
@@ -13,12 +13,12 @@ fn levenshtein_distance(s1: &[u8], s2: &[u8]) -> usize {
     let m = s1_bytes.len();
 
     // Use two rows instead of full matrix for space optimization
-    let mut prev_row: Vec<usize> = (0..m + 1).collect();
-    let mut curr_row: Vec<usize> = vec![0; m + 1];
+    let mut prev_row: Vec<u32> = (0..m + 1).map(|b| b as u32).collect();
+    let mut curr_row: Vec<u32> = vec![0; m + 1];
 
     // Main computation loop
     for (j, s2) in s2_bytes.iter().enumerate() {
-        curr_row[0] = j + 1;
+        curr_row[0] = (j + 1) as u32;
 
         for (i, s1) in s1_bytes.iter().enumerate() {
             let cost = if s1 == s2 { 0 } else { 1 };
@@ -65,5 +65,5 @@ fn main() {
     }
 
     println!("times: {}", times);
-    println!("min_distance: {}", min_distance.unwrap_or(usize::MAX));
+    println!("min_distance: {}", min_distance.unwrap_or(u32::MAX));
 }

--- a/levenshtein/rust/code.rs
+++ b/levenshtein/rust/code.rs
@@ -3,54 +3,38 @@ use std::env;
 /// Calculates the Levenshtein distance between two strings using Wagner-Fischer algorithm
 /// Space Complexity: O(min(m,n)) - only uses two rows instead of full matrix
 /// Time Complexity: O(m*n) where m and n are the lengths of the input strings
-fn levenshtein_distance(s1: &str, s2: &str) -> usize {
-    // Early termination checks
-    if s1 == s2 {
-        return 0;
-    }
-    if s1.is_empty() {
-        return s2.len();
-    }
-    if s2.is_empty() {
-        return s1.len();
-    }
-
-    // Convert to bytes for faster access
-    let s1_bytes = s1.as_bytes();
-    let s2_bytes = s2.as_bytes();
-
-    // Make s1 the shorter string for space optimization
-    let (s1_bytes, s2_bytes) = if s1_bytes.len() > s2_bytes.len() {
-        (s2_bytes, s1_bytes)
+fn levenshtein_distance(s1: &[u8], s2: &[u8]) -> usize {
+    let (s1_bytes, s2_bytes) = if s1.len() > s2.len() {
+        (s2, s1)
     } else {
-        (s1_bytes, s2_bytes)
+        (s1, s2)
     };
 
     let m = s1_bytes.len();
     let n = s2_bytes.len();
 
     // Use two rows instead of full matrix for space optimization
-    let mut prev_row = Vec::with_capacity(m + 1);
-    let mut curr_row = Vec::with_capacity(m + 1);
-
-    // Initialize first row
-    prev_row.extend(0..=m);
-    curr_row.resize(m + 1, 0);
+    let mut prev_row = vec![0; m + 1];
+    let mut curr_row = vec![0; m + 1];
 
     // Main computation loop
     for j in 1..=n {
         curr_row[0] = j;
 
         for i in 1..=m {
-            let cost = if s1_bytes[i - 1] == s2_bytes[j - 1] { 0 } else { 1 };
-            
+            let cost = if s1_bytes[i - 1] == s2_bytes[j - 1] {
+                0
+            } else {
+                1
+            };
+
             // Calculate minimum of three operations
             curr_row[i] = std::cmp::min(
                 std::cmp::min(
-                    prev_row[i] + 1,      // deletion
-                    curr_row[i - 1] + 1,  // insertion
+                    prev_row[i] + 1,     // deletion
+                    curr_row[i - 1] + 1, // insertion
                 ),
-                prev_row[i - 1] + cost    // substitution
+                prev_row[i - 1] + cost, // substitution
             );
         }
 
@@ -76,7 +60,7 @@ fn main() {
     for i in 0..args.len() {
         for j in 0..args.len() {
             if i != j {
-                let distance = levenshtein_distance(&args[i], &args[j]);
+                let distance = levenshtein_distance(args[i].as_bytes(), args[j].as_bytes());
                 if let Some(current_min) = min_distance {
                     if distance < current_min {
                         min_distance = Some(distance);

--- a/levenshtein/rust/code.rs
+++ b/levenshtein/rust/code.rs
@@ -17,10 +17,10 @@ fn levenshtein_distance(s1: &[u8], s2: &[u8]) -> u32 {
     let mut curr_row: Vec<u32> = vec![0; m + 1];
 
     // Main computation loop
-    for (j, s2) in s2_bytes.iter().copied().enumerate() {
+    for (j, s2) in s2_bytes.iter().enumerate() {
         curr_row[0] = (j + 1) as u32;
 
-        for (i, s1) in s1_bytes.iter().copied().enumerate() {
+        for (i, s1) in s1_bytes.iter().enumerate() {
             let cost = if s1 == s2 { 0 } else { 1 };
 
             // Calculate minimum of three operations

--- a/levenshtein/rust/code.rs
+++ b/levenshtein/rust/code.rs
@@ -3,7 +3,7 @@ use std::env;
 /// Calculates the Levenshtein distance between two strings using Wagner-Fischer algorithm
 /// Space Complexity: O(min(m,n)) - only uses two rows instead of full matrix
 /// Time Complexity: O(m*n) where m and n are the lengths of the input strings
-fn levenshtein_distance(s1: &[u8], s2: &[u8]) -> usize {
+fn levenshtein_distance(s1: &[u8], s2: &[u8]) -> u32 {
     let (s1_bytes, s2_bytes) = if s1.len() > s2.len() {
         (s2, s1)
     } else {
@@ -14,12 +14,12 @@ fn levenshtein_distance(s1: &[u8], s2: &[u8]) -> usize {
     let n = s2_bytes.len();
 
     // Use two rows instead of full matrix for space optimization
-    let mut prev_row = vec![0; m + 1];
-    let mut curr_row = vec![0; m + 1];
+    let mut prev_row = vec![0u32; m + 1];
+    let mut curr_row = vec![0u32; m + 1];
 
     // Main computation loop
     for j in 1..=n {
-        curr_row[0] = j;
+        curr_row[0] = j as u32;
 
         for i in 1..=m {
             let cost = if s1_bytes[i - 1] == s2_bytes[j - 1] {
@@ -70,5 +70,5 @@ fn main() {
     }
 
     println!("times: {}", times);
-    println!("min_distance: {}", min_distance.unwrap_or(usize::MAX));
+    println!("min_distance: {}", min_distance.unwrap_or(u32::MAX));
 }

--- a/levenshtein/rust/code.rs
+++ b/levenshtein/rust/code.rs
@@ -13,8 +13,8 @@ fn levenshtein_distance(s1: &[u8], s2: &[u8]) -> u32 {
     let m = s1_bytes.len();
 
     // Use two rows instead of full matrix for space optimization
-    let mut prev_row = vec![0u32; m + 1];
-    let mut curr_row = vec![0u32; m + 1];
+    let mut prev_row: Vec<u32> = (0..=m).map(|b| b as u32).collect();
+    let mut curr_row: Vec<u32> = vec![0; m + 1];
 
     // Main computation loop
     for (j, s2) in s2_bytes.iter().copied().enumerate() {

--- a/levenshtein/rust/code.rs
+++ b/levenshtein/rust/code.rs
@@ -11,18 +11,17 @@ fn levenshtein_distance(s1: &[u8], s2: &[u8]) -> u32 {
     };
 
     let m = s1_bytes.len();
-    let n = s2_bytes.len();
 
     // Use two rows instead of full matrix for space optimization
     let mut prev_row = vec![0u32; m + 1];
     let mut curr_row = vec![0u32; m + 1];
 
     // Main computation loop
-    for j in 1..=n {
-        curr_row[0] = j as u32;
+    for (j, s2) in s2_bytes.iter().copied().enumerate() {
+        curr_row[0] = (j + 1) as u32;
 
         for (i, s1) in s1_bytes.iter().copied().enumerate() {
-            let cost = if s1 == s2_bytes[j - 1] { 0 } else { 1 };
+            let cost = if s1 == s2 { 0 } else { 1 };
 
             // Calculate minimum of three operations
             curr_row[i + 1] = (prev_row[i + 1] + 1) // deletion

--- a/levenshtein/rust/code.rs
+++ b/levenshtein/rust/code.rs
@@ -21,17 +21,13 @@ fn levenshtein_distance(s1: &[u8], s2: &[u8]) -> u32 {
     for j in 1..=n {
         curr_row[0] = j as u32;
 
-        for i in 1..=m {
-            let cost = if s1_bytes[i - 1] == s2_bytes[j - 1] {
-                0
-            } else {
-                1
-            };
+        for (i, s1) in s1_bytes.iter().copied().enumerate() {
+            let cost = if s1 == s2_bytes[j - 1] { 0 } else { 1 };
 
             // Calculate minimum of three operations
-            curr_row[i] = (prev_row[i] + 1) // deletion
-                .min(curr_row[i - 1] + 1) // insertion
-                .min(prev_row[i - 1] + cost); // substitution
+            curr_row[i + 1] = (prev_row[i + 1] + 1) // deletion
+                .min(curr_row[i] + 1) // insertion
+                .min(prev_row[i] + cost); // substitution
         }
 
         // Swap rows

--- a/levenshtein/rust/code.rs
+++ b/levenshtein/rust/code.rs
@@ -3,7 +3,7 @@ use std::env;
 /// Calculates the Levenshtein distance between two strings using Wagner-Fischer algorithm
 /// Space Complexity: O(min(m,n)) - only uses two rows instead of full matrix
 /// Time Complexity: O(m*n) where m and n are the lengths of the input strings
-fn levenshtein_distance(s1: &[u8], s2: &[u8]) -> u32 {
+fn levenshtein_distance(s1: &[u8], s2: &[u8]) -> usize {
     let (s1_bytes, s2_bytes) = if s1.len() > s2.len() {
         (s2, s1)
     } else {
@@ -13,12 +13,12 @@ fn levenshtein_distance(s1: &[u8], s2: &[u8]) -> u32 {
     let m = s1_bytes.len();
 
     // Use two rows instead of full matrix for space optimization
-    let mut prev_row: Vec<u32> = (0..m + 1).map(|b| b as u32).collect();
-    let mut curr_row: Vec<u32> = vec![0; m + 1];
+    let mut prev_row: Vec<usize> = (0..m + 1).collect();
+    let mut curr_row: Vec<usize> = vec![0; m + 1];
 
     // Main computation loop
     for (j, s2) in s2_bytes.iter().enumerate() {
-        curr_row[0] = (j + 1) as u32;
+        curr_row[0] = j + 1;
 
         for (i, s1) in s1_bytes.iter().enumerate() {
             let cost = if s1 == s2 { 0 } else { 1 };
@@ -65,5 +65,5 @@ fn main() {
     }
 
     println!("times: {}", times);
-    println!("min_distance: {}", min_distance.unwrap_or(u32::MAX));
+    println!("min_distance: {}", min_distance.unwrap_or(usize::MAX));
 }

--- a/levenshtein/rust/code.rs
+++ b/levenshtein/rust/code.rs
@@ -13,7 +13,7 @@ fn levenshtein_distance(s1: &[u8], s2: &[u8]) -> u32 {
     let m = s1_bytes.len();
 
     // Use two rows instead of full matrix for space optimization
-    let mut prev_row: Vec<u32> = (0..=m).map(|b| b as u32).collect();
+    let mut prev_row: Vec<u32> = (0..m + 1).map(|b| b as u32).collect();
     let mut curr_row: Vec<u32> = vec![0; m + 1];
 
     // Main computation loop

--- a/levenshtein/rust/code.rs
+++ b/levenshtein/rust/code.rs
@@ -40,30 +40,34 @@ fn main() {
     let args: Vec<String> = env::args().skip(1).collect();
 
     if args.len() < 2 {
-        println!("Please provide at least two strings as arguments.");
+        eprintln!("Please provide at least two strings as arguments.");
         return;
     }
 
-    let mut min_distance = None;
+    if !args.iter().all(|s| s.is_ascii()) {
+        eprintln!("This benchmark assumes ASCII string values.");
+        return;
+    }
+
+    if args.iter().any(|s| s.is_empty()) {
+        eprintln!("This benchmark assumes non-empty strings.");
+        return;
+    }
+
+    let mut min_distance = u32::MAX;
     let mut times = 0;
 
     // Compare all pairs of strings
-    for i in 0..args.len() {
-        for j in 0..args.len() {
+    for (i, s1) in args.iter().enumerate() {
+        for (j, s2) in args.iter().enumerate() {
             if i != j {
-                let distance = levenshtein_distance(args[i].as_bytes(), args[j].as_bytes());
-                if let Some(current_min) = min_distance {
-                    if distance < current_min {
-                        min_distance = Some(distance);
-                    }
-                } else {
-                    min_distance = Some(distance);
-                }
+                let distance = levenshtein_distance(s1.as_bytes(), s2.as_bytes());
+                min_distance = min_distance.min(distance);
                 times += 1;
             }
         }
     }
 
-    println!("times: {}", times);
-    println!("min_distance: {}", min_distance.unwrap_or(u32::MAX));
+    println!("times: {times}");
+    println!("min_distance: {min_distance}");
 }


### PR DESCRIPTION
## Description of changes

Modifies the Rust implementation for Levenshtein to make it more like the C one.
- Switches from `usize` (usually 64-bit) to `u32`
- Uses iterators to get rid of some bounds checking
- Clean up style and make more idiomatic.

Passed the check, compiles, and runs via the test harness.