### PR TITLE
set row length to string length plus one

### DIFF
--- a/levenshtein/zig/code.zig
+++ b/levenshtein/zig/code.zig
@@ -64,8 +64,8 @@ pub fn main() !void {
     const max_inp_len = std.mem.max(usize, input_lengths);
 
     // Reuse prev and curr row to minimize allocations
-    const prev_row = try allocator.alloc(usize, max_inp_len);
-    const curr_row = try allocator.alloc(usize, max_inp_len);
+    const prev_row = try allocator.alloc(usize, max_inp_len + 1);
+    const curr_row = try allocator.alloc(usize, max_inp_len + 1);
 
     var min_distance: isize = -1;
     var times: usize = 0;


### PR DESCRIPTION
Fixes following error:
`panic: index out of bounds: index 750, len 750`

---

<!-- Thanks for helping to improve this project! 🙏 -->

I have:

* [x] Read the project [README](../README.md), including the [benchmark descriptions](../README.md#available-benchmarks)

## Description of changes

This error can be recreated by omitting the `ReleaseFast` flag for compilation or using `ReleaseSafe` instead.
```Zig
zig build-exe -O ReleaseSafe …
```

This way Zig will always check array bounds when accessing elements via their index and throw a panic.
The maximum number of elements for the rows only contain `string length` elements, but their capacity should be `string length + 1`.

The [_ReleaseFast_ flag omits all safety checks](https://ziglang.org/documentation/master/#ReleaseFast) and hides the underlying problem.

---

Apart from that, the Zig code takes almost twice as long as the C(pp) and Rust codes. Unfortunately, I am not familiar enough with Zig to find the exact cause.

<!-- 

Please include a descrition for your change. Things like:

* Why it is done (a problem description)
  If there's an issue describing the problem, please refer it. If your PR is fixing the problem described in the issue, use the _Fixes #<issue-no>_  syntax.
* Why it is done the way you have done it (a solution description)

Please help us understand the changes and the rationale even if we are not experts or even familiar with the particular language you are providing changes for.

If you provide changes to the implementation of one or more language, for one or more benchmark, please include output from benchmark runs, before and after the change.

Thanks again for contributing!
-->

