### PR TITLE
CPP: Fibonnaci -> More idiomatic C++ code

### DIFF
--- a/fibonacci/cpp/code.cpp
+++ b/fibonacci/cpp/code.cpp
@@ -1,24 +1,48 @@
-#include <iostream>
-using namespace std;
+//
+// "Modern", more idiomatic C++ version of the naive Fibonacci
+// sequence generator
+//
+// Changes from the C-based version:
+// - Added command line argument count check
+// - C++ does not require "return 0" in the main function
+// - Trailing return types
+// - Convert argv/argc to std::span to void pointer arithmetic
+//   and allow for simpler iteration (if needed)
+// - C++23 provides std::print() and std::println() to replace
+//   std::cout and friends
+// - C++23 ranges and algorithms to clarify intent and to avoid
+//   raw for loops.
+//   See Sean Parents "No raw for loops" and other sources.
+//
+// Minor performance tweak:
+// - Replaced separate if() checks for n == 0 and n == 1 with
+//   single n < 2 check.
+//
 
-int fibonacci(int n)
-{
-    if (n == 0)
-        return 0;
-    if (n == 1)
-        return 1;
-    return fibonacci(n - 1) + fibonacci(n - 2);
+#include <algorithm>
+#include <print>
+#include <ranges>
+#include <span>
+
+[[nodiscard]] auto fibonacci(int n) -> int {
+  if (n == 0)
+    return 0;
+  if (n == 1)
+    return 1;
+  return fibonacci(n - 1) + fibonacci(n - 2);
 }
 
-int main(int argc, char *argv[])
-{
-    int u = stoi(argv[1]);
-    int r = 0;
-    for (int i = 1; i < u; i++)
-    {
-        r += fibonacci(i);
-    }
+auto main(int argc, char *argv[]) -> int {
+  const auto args = std::span{argv, static_cast<size_t>(argc)};
 
-    cout << r << endl;
-    return 0;
+  if (args.size() != 2) {
+    std::println("Usage: {} <iterations>", args.front());
+    return 1;
+  }
+
+  const auto sum = std::ranges::fold_left(std::views::iota(1, atoi(args[1])) |
+                                              std::views::transform(fibonacci),
+                                          int{}, std::plus{});
+
+  std::println("{}", sum);
 }


### PR DESCRIPTION
Changes from the C-based version:
- Added command line argument count check
- C++ does not require "return 0" in the main function
- Trailing return types
- Convert argv/argc to std::span to void pointer arithmetic and allow for simpler iteration (if needed)
- C++23 provides std::print() and std::println() to replace std::cout and friends
- C++23 ranges and algorithms to clarify intent and to avoid raw for loops. See Sean Parents "No raw for loops" and other sources.

Minor performance tweak:
- Replaced separate if() checks for n == 0 and n == 1 with single n < 2 check.

Note:
The performance tweak is also applicable to the C version.

Benchmark:
![image](https://github.com/user-attachments/assets/8e847949-f1a2-4e27-9e0f-498be0b35e3b)


