### PR TITLE
CPP: Hello, World! C++23 style

### DIFF
--- a/hello-world/cpp/code.cpp
+++ b/hello-world/cpp/code.cpp
@@ -1,6 +1,5 @@
-#include <iostream>
+#include <print>
 
-int main() {
-    std::cout << "Hello, World!" << std::endl;
-    return 0;
+auto main() -> int {
+    std::println("Hello, World!");
 }


### PR DESCRIPTION
- C++ does not require "return 0" in main()

- std::endl should almost never be used as it flushes the output in addition to adding a newline. 
This is a performance issue in real world programs and should not be "trained" by default. If iostream is still used, simply print newlines like this: std::cout << "Hello, World!\n";

- Move to C++23 std::print / std::println

- Trailing return types

