### PR TITLE
Add in-process Fortran benchmark utility and implement all benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ levenshtein/*/run
 hello-world/*/code
 hello-world/*/run
 .nrepl-port
+
+lib/fortran/benchmark.mod

--- a/compile.sh
+++ b/compile.sh
@@ -56,7 +56,7 @@ compile 'Clojure' 'clojure' '(cd clojure && mkdir -p classes && clojure -M -e "(
 compile 'Clojure Native' 'clojure-native-image' "(cd clojure-native-image ; clojure -M:native-image-run --pgo-instrument -march=native) ; ./clojure-native-image/run -XX:ProfilesDumpFile=clojure-native-image/run.iprof 10000 2000 $(./check-output.sh -i) && (cd clojure-native-image ; clojure -M:native-image-run --pgo=run.iprof -march=native)"
 compile 'Java' 'jvm' 'javac -cp ../lib/java jvm/run.java'
 compile 'Java Native' 'java-native-image' "(cd java-native-image ; native-image -cp ..:../../lib/java --no-fallback -O3 --pgo-instrument -march=native jvm.run) && ./java-native-image/jvm.run -XX:ProfilesDumpFile=java-native-image/run.iprof 10000 2000 $(./check-output.sh -i) && (cd java-native-image ; native-image -cp ..:../../lib/java -O3 --pgo=run.iprof -march=native jvm.run -o run)"
-compile 'Fortran' 'fortran' 'gfortran -O3 -I../lib/fortran ../lib/fortran/benchmark.f90 fortran/run.f90 -o fortran/run'
+compile 'Fortran' 'fortran' "gfortran -O3 -J../lib/fortran ../lib/fortran/benchmark.f90 fortran/run.f90 -o fortran/run"
 
 ####### END The languages
 

--- a/compile.sh
+++ b/compile.sh
@@ -56,6 +56,8 @@ compile 'Clojure' 'clojure' '(cd clojure && mkdir -p classes && clojure -M -e "(
 compile 'Clojure Native' 'clojure-native-image' "(cd clojure-native-image ; clojure -M:native-image-run --pgo-instrument -march=native) ; ./clojure-native-image/run -XX:ProfilesDumpFile=clojure-native-image/run.iprof 10000 2000 $(./check-output.sh -i) && (cd clojure-native-image ; clojure -M:native-image-run --pgo=run.iprof -march=native)"
 compile 'Java' 'jvm' 'javac -cp ../lib/java jvm/run.java'
 compile 'Java Native' 'java-native-image' "(cd java-native-image ; native-image -cp ..:../../lib/java --no-fallback -O3 --pgo-instrument -march=native jvm.run) && ./java-native-image/jvm.run -XX:ProfilesDumpFile=java-native-image/run.iprof 10000 2000 $(./check-output.sh -i) && (cd java-native-image ; native-image -cp ..:../../lib/java -O3 --pgo=run.iprof -march=native jvm.run -o run)"
+compile 'Fortran' 'fortran' 'gfortran -O3 -I../lib/fortran ../lib/fortran/benchmark.f90 fortran/run.f90 -o fortran/run'
+
 ####### END The languages
 
 echo

--- a/fibonacci/fortran/run.f90
+++ b/fibonacci/fortran/run.f90
@@ -1,0 +1,45 @@
+program main
+    use benchmark
+    implicit none
+    integer(8) :: n
+    integer(4) :: run_ms, warmup_ms
+    character(len=256) :: arg
+    type(benchmark_result_t) :: warmup_result, benchmark_result
+    character(len = :), allocatable :: result_str
+
+    call get_command_argument(1, arg)
+    read(arg, *) run_ms                 ! Convert the command-line argument to integer
+    call get_command_argument(2, arg)
+    read(arg, *) warmup_ms              ! Convert the command-line argument to integer
+    call get_command_argument(3, arg)
+    read(arg, *) n                      ! Convert the command-line argument to integer
+
+    call run(fibonacci_benchmark, warmup_ms, warmup_result)
+    call run(fibonacci_benchmark, run_ms, benchmark_result)
+
+    call format_results(benchmark_result, result_str)
+    write(*, '(A)') trim(adjustl(result_str))
+
+contains
+
+    integer(8) function fibonacci_benchmark()
+        implicit none
+        integer(8) :: result
+
+        result = fibonacci(n)
+        fibonacci_benchmark = result
+    end function fibonacci_benchmark
+
+    integer(8) recursive function fibonacci(n) result(f)
+        integer(8), intent(in) :: n
+
+        if (n == 0) then
+            f = 0
+        elseif (n == 1) then
+            f = 1
+        else
+            f = fibonacci(n - 1) + fibonacci(n - 2)
+        end if
+    end function fibonacci
+
+end program main

--- a/hello-world/fortran/run.f90
+++ b/hello-world/fortran/run.f90
@@ -1,0 +1,3 @@
+program main
+    print *, "Hello, World!"                   
+end program main

--- a/levenshtein/clojure/run.clj
+++ b/levenshtein/clojure/run.clj
@@ -57,6 +57,6 @@
         println)))
 
 (comment
-  (-main "1000" "levenshtein/levenshtein-words.txt")
+  (-main "2000" "1000" "levenshtein-words.txt")
   :rcf)
 

--- a/levenshtein/fortran/run.f90
+++ b/levenshtein/fortran/run.f90
@@ -3,11 +3,11 @@ program main
    implicit none
 
    integer :: run_ms, warmup_ms, iostat, word_count
-   character(len=256) :: run_ms_str, warmup_ms_str, input_path
-   character(len=:), allocatable :: args(:)
+   character(len = 256) :: run_ms_str, warmup_ms_str, input_path
+   character(len = :), allocatable :: args(:)
    integer, allocatable :: distances(:)
    type(benchmark_result_t) :: warmup_result, benchmark_result
-   character(len=256) :: result_str
+   character(len = 256) :: result_str
 
    call get_command_argument(1, run_ms_str)
    call get_command_argument(2, warmup_ms_str)
@@ -20,19 +20,19 @@ program main
    word_count = size(args)
    if (word_count == 0) stop "No words read."
 
-   allocate(distances((word_count*(word_count-1))/2))
+   allocate(distances((word_count * (word_count - 1)) / 2))
    call run(benchmark_function, warmup_ms, warmup_result)
    call run(benchmark_function, run_ms, benchmark_result)
    benchmark_result%result = sum(distances)
 
    call format_results(benchmark_result, result_str)
-   write(*,'(A)') result_str
+   write(*, '(A)') result_str
 
    deallocate(args, distances)
 
-contains
+   contains
 
-   integer(8) function benchmark_function()
+      integer(8) function benchmark_function()
       implicit none
       integer :: i, j, idx
       integer(8) :: sum_distances
@@ -48,42 +48,43 @@ contains
       benchmark_function = sum_distances
    end function benchmark_function
 
-subroutine read_all_words(filename, all_words, iostat)
-   implicit none
-   character(len=*), intent(in) :: filename
-   character(len=:), allocatable, intent(out) :: all_words(:)
-   integer, intent(out) :: iostat
-   integer :: unit, num_words, i
-   character(len=256) :: word
+   subroutine read_all_words(filename, all_words, iostat)
+      implicit none
+      character(len = *), intent(in) :: filename
+      character(len = :), allocatable, intent(out) :: all_words(:)
+      integer, intent(out) :: iostat
+      integer :: unit, num_words, i
+      integer, parameter :: max_len = 10000 ! Allow for really long words
+      character(len = max_len) :: word
 
-   open(newunit=unit, file=filename, status='old', action='read', iostat=iostat)
-   if (iostat /= 0) return
+      open(newunit = unit, file = filename, status = 'old', action = 'read', iostat = iostat)
+      if (iostat /= 0) return
 
-   num_words = 0
-   do
-      read(unit, '(A)', iostat=iostat) word
-      if (iostat /= 0) exit
-      num_words = num_words + 1
-   end do
-
-   if (num_words > 0) then
-      allocate(character(len=256) :: all_words(num_words))
-      rewind(unit)
-      do i = 1, num_words
-         read(unit, '(A)', iostat=iostat) all_words(i)
+      num_words = 0
+      do
+         read(unit, '(A)', iostat = iostat) word
          if (iostat /= 0) exit
+         num_words = num_words + 1
       end do
-   else
-      allocate(all_words, mold=[character(len=256) :: ''])
-   end if
 
-   close(unit)
-end subroutine read_all_words
+      if (num_words > 0) then
+         allocate(character(len = max_len) :: all_words(num_words))
+         rewind(unit)
+         do i = 1, num_words
+            read(unit, '(A)', iostat = iostat) all_words(i)
+            if (iostat /= 0) exit
+         end do
+      else
+         allocate(all_words, mold = [character(len = max_len) :: ''])
+      end if
+
+      close(unit)
+   end subroutine read_all_words
 
    subroutine split(string, delimiter, parts)
-      character(len=*), intent(in)  :: string
-      character(len=*), intent(in)  :: delimiter
-      character(len=*), intent(out) :: parts(:)
+      character(len = *), intent(in) :: string
+      character(len = *), intent(in) :: delimiter
+      character(len = *), intent(out) :: parts(:)
       integer :: i, start, finish, p
       start = 1
       p = 1
@@ -106,84 +107,84 @@ end subroutine read_all_words
       end if
    end subroutine split
 
-  ! Calculates the Levenshtein distance between two strings using Wagner-Fischer algorithm
-  ! Space Complexity: O(min(m,n)) - only uses two arrays instead of full matrix
-  ! Time Complexity: O(m*n) where m and n are the lengths of the input strings
-  function levenshtein_distance(s1, s2) result(distance)
-      character(len=*), intent(in) :: s1, s2
+   ! Calculates the Levenshtein distance between two strings using Wagner-Fischer algorithm
+   ! Space Complexity: O(min(m,n)) - only uses two arrays instead of full matrix
+   ! Time Complexity: O(m*n) where m and n are the lengths of the input strings
+   function levenshtein_distance(s1, s2) result(distance)
+      character(len = *), intent(in) :: s1, s2
       integer :: distance
-      
+
       integer :: m, n, i, j, cost
       integer, allocatable :: prev_row(:), curr_row(:)
-      character(len=1) :: c1, c2
-      character(len=:), allocatable :: str1, str2
-      
+      character(len = 1) :: c1, c2
+      character(len = :), allocatable :: str1, str2
+
       ! Early termination checks
       if (s1 == s2) then
-          distance = 0
-          return
+         distance = 0
+         return
       end if
-      
+
       if (len_trim(s1) == 0) then
-          distance = len_trim(s2)
-          return
+         distance = len_trim(s2)
+         return
       end if
-      
+
       if (len_trim(s2) == 0) then
-          distance = len_trim(s1)
-          return
+         distance = len_trim(s1)
+         return
       end if
-      
+
       ! Make s1 the shorter string for space optimization
       if (len_trim(s1) > len_trim(s2)) then
-          str1 = trim(s2)
-          str2 = trim(s1)
+         str1 = trim(s2)
+         str2 = trim(s1)
       else
-          str1 = trim(s1)
-          str2 = trim(s2)
+         str1 = trim(s1)
+         str2 = trim(s2)
       end if
-      
+
       m = len_trim(str1)
       n = len_trim(str2)
-      
+
       ! Use two arrays instead of full matrix for space optimization
       allocate(prev_row(0:m), curr_row(0:m))
-      
+
       ! Initialize first row
       do i = 0, m
-          prev_row(i) = i
+         prev_row(i) = i
       end do
-      
+
       ! Main computation loop
       do j = 1, n
-          curr_row(0) = j
-          
-          do i = 1, m
-              ! Get characters at current position
-              c1 = str1(i:i)
-              c2 = str2(j:j)
-              
-              ! Calculate cost
-              if (c1 == c2) then
-                  cost = 0
-              else
-                  cost = 1
-              end if
-              
-              ! Calculate minimum of three operations
-              curr_row(i) = min(prev_row(i) + 1,      & ! deletion
-                              curr_row(i-1) + 1,      & ! insertion
-                              prev_row(i-1) + cost)     ! substitution
-          end do
-          
-          ! Swap rows
-          prev_row = curr_row
+         curr_row(0) = j
+
+         do i = 1, m
+            ! Get characters at current position
+            c1 = str1(i:i)
+            c2 = str2(j:j)
+
+            ! Calculate cost
+            if (c1 == c2) then
+               cost = 0
+            else
+               cost = 1
+            end if
+
+            ! Calculate minimum of three operations
+            curr_row(i) = min(prev_row(i) + 1, & ! deletion
+            curr_row(i - 1) + 1, & ! insertion
+            prev_row(i - 1) + cost)     ! substitution
+         end do
+
+         ! Swap rows
+         prev_row = curr_row
       end do
-      
+
       distance = prev_row(m)
-      
+
       ! Clean up
       deallocate(prev_row, curr_row)
-  end function levenshtein_distance
+   end function levenshtein_distance
 
 end program main

--- a/levenshtein/fortran/run.f90
+++ b/levenshtein/fortran/run.f90
@@ -1,0 +1,189 @@
+program main
+   use benchmark
+   implicit none
+
+   integer :: run_ms, warmup_ms, iostat, word_count
+   character(len=256) :: run_ms_str, warmup_ms_str, input_path
+   character(len=:), allocatable :: args(:)
+   integer, allocatable :: distances(:)
+   type(benchmark_result_t) :: warmup_result, benchmark_result
+   character(len=256) :: result_str
+
+   call get_command_argument(1, run_ms_str)
+   call get_command_argument(2, warmup_ms_str)
+   call get_command_argument(3, input_path)
+   read(run_ms_str, *) run_ms
+   read(warmup_ms_str, *) warmup_ms
+
+   call read_all_words(input_path, args, iostat)
+   if (iostat /= 0) stop "Error reading file."
+   word_count = size(args)
+   if (word_count == 0) stop "No words read."
+
+   allocate(distances((word_count*(word_count-1))/2))
+   call run(benchmark_function, warmup_ms, warmup_result)
+   call run(benchmark_function, run_ms, benchmark_result)
+   benchmark_result%result = sum(distances)
+
+   call format_results(benchmark_result, result_str)
+   write(*,'(A)') result_str
+
+   deallocate(args, distances)
+
+contains
+
+   integer(8) function benchmark_function()
+      implicit none
+      integer :: i, j, idx
+      integer(8) :: sum_distances
+      sum_distances = 0
+      idx = 1
+      do i = 1, size(args)
+         do j = i + 1, size(args)
+            distances(idx) = levenshtein_distance(trim(args(i)), trim(args(j)))
+            sum_distances = sum_distances + distances(idx)
+            idx = idx + 1
+         end do
+      end do
+      benchmark_function = sum_distances
+   end function benchmark_function
+
+subroutine read_all_words(filename, all_words, iostat)
+   implicit none
+   character(len=*), intent(in) :: filename
+   character(len=:), allocatable, intent(out) :: all_words(:)
+   integer, intent(out) :: iostat
+   integer :: unit, num_words, i
+   character(len=256) :: word
+
+   open(newunit=unit, file=filename, status='old', action='read', iostat=iostat)
+   if (iostat /= 0) return
+
+   num_words = 0
+   do
+      read(unit, '(A)', iostat=iostat) word
+      if (iostat /= 0) exit
+      num_words = num_words + 1
+   end do
+
+   if (num_words > 0) then
+      allocate(character(len=256) :: all_words(num_words))
+      rewind(unit)
+      do i = 1, num_words
+         read(unit, '(A)', iostat=iostat) all_words(i)
+         if (iostat /= 0) exit
+      end do
+   else
+      allocate(all_words, mold=[character(len=256) :: ''])
+   end if
+
+   close(unit)
+end subroutine read_all_words
+
+   subroutine split(string, delimiter, parts)
+      character(len=*), intent(in)  :: string
+      character(len=*), intent(in)  :: delimiter
+      character(len=*), intent(out) :: parts(:)
+      integer :: i, start, finish, p
+      start = 1
+      p = 1
+      do i = 1, len(string)
+         if (string(i:i) == delimiter) then
+            finish = i - 1
+            if (finish < start) then
+               parts(p) = ''
+            else
+               parts(p) = string(start:finish)
+            end if
+            p = p + 1
+            start = i + 1
+         end if
+      end do
+      if (start <= len(string)) then
+         parts(p) = string(start:)
+      else
+         parts(p) = ''
+      end if
+   end subroutine split
+
+  ! Calculates the Levenshtein distance between two strings using Wagner-Fischer algorithm
+  ! Space Complexity: O(min(m,n)) - only uses two arrays instead of full matrix
+  ! Time Complexity: O(m*n) where m and n are the lengths of the input strings
+  function levenshtein_distance(s1, s2) result(distance)
+      character(len=*), intent(in) :: s1, s2
+      integer :: distance
+      
+      integer :: m, n, i, j, cost
+      integer, allocatable :: prev_row(:), curr_row(:)
+      character(len=1) :: c1, c2
+      character(len=:), allocatable :: str1, str2
+      
+      ! Early termination checks
+      if (s1 == s2) then
+          distance = 0
+          return
+      end if
+      
+      if (len_trim(s1) == 0) then
+          distance = len_trim(s2)
+          return
+      end if
+      
+      if (len_trim(s2) == 0) then
+          distance = len_trim(s1)
+          return
+      end if
+      
+      ! Make s1 the shorter string for space optimization
+      if (len_trim(s1) > len_trim(s2)) then
+          str1 = trim(s2)
+          str2 = trim(s1)
+      else
+          str1 = trim(s1)
+          str2 = trim(s2)
+      end if
+      
+      m = len_trim(str1)
+      n = len_trim(str2)
+      
+      ! Use two arrays instead of full matrix for space optimization
+      allocate(prev_row(0:m), curr_row(0:m))
+      
+      ! Initialize first row
+      do i = 0, m
+          prev_row(i) = i
+      end do
+      
+      ! Main computation loop
+      do j = 1, n
+          curr_row(0) = j
+          
+          do i = 1, m
+              ! Get characters at current position
+              c1 = str1(i:i)
+              c2 = str2(j:j)
+              
+              ! Calculate cost
+              if (c1 == c2) then
+                  cost = 0
+              else
+                  cost = 1
+              end if
+              
+              ! Calculate minimum of three operations
+              curr_row(i) = min(prev_row(i) + 1,      & ! deletion
+                              curr_row(i-1) + 1,      & ! insertion
+                              prev_row(i-1) + cost)     ! substitution
+          end do
+          
+          ! Swap rows
+          prev_row = curr_row
+      end do
+      
+      distance = prev_row(m)
+      
+      ! Clean up
+      deallocate(prev_row, curr_row)
+  end function levenshtein_distance
+
+end program main

--- a/levenshtein/fortran/run.f90
+++ b/levenshtein/fortran/run.f90
@@ -81,32 +81,6 @@ program main
       close(unit)
    end subroutine read_all_words
 
-   subroutine split(string, delimiter, parts)
-      character(len = *), intent(in) :: string
-      character(len = *), intent(in) :: delimiter
-      character(len = *), intent(out) :: parts(:)
-      integer :: i, start, finish, p
-      start = 1
-      p = 1
-      do i = 1, len(string)
-         if (string(i:i) == delimiter) then
-            finish = i - 1
-            if (finish < start) then
-               parts(p) = ''
-            else
-               parts(p) = string(start:finish)
-            end if
-            p = p + 1
-            start = i + 1
-         end if
-      end do
-      if (start <= len(string)) then
-         parts(p) = string(start:)
-      else
-         parts(p) = ''
-      end if
-   end subroutine split
-
    ! Calculates the Levenshtein distance between two strings using Wagner-Fischer algorithm
    ! Space Complexity: O(min(m,n)) - only uses two arrays instead of full matrix
    ! Time Complexity: O(m*n) where m and n are the lengths of the input strings

--- a/levenshtein/fortran/run.f90
+++ b/levenshtein/fortran/run.f90
@@ -7,7 +7,7 @@ program main
    character(len = :), allocatable :: args(:)
    integer, allocatable :: distances(:)
    type(benchmark_result_t) :: warmup_result, benchmark_result
-   character(len = 256) :: result_str
+   character(len = :), allocatable :: result_str
 
    call get_command_argument(1, run_ms_str)
    call get_command_argument(2, warmup_ms_str)
@@ -26,7 +26,7 @@ program main
    benchmark_result%result = sum(distances)
 
    call format_results(benchmark_result, result_str)
-   write(*, '(A)') result_str
+   write(*, '(A)') trim(adjustl(result_str))
 
    deallocate(args, distances)
 

--- a/levenshtein/fortran/run.f90
+++ b/levenshtein/fortran/run.f90
@@ -23,6 +23,8 @@ program main
    allocate(distances((word_count * (word_count - 1)) / 2))
    call run(benchmark_function, warmup_ms, warmup_result)
    call run(benchmark_function, run_ms, benchmark_result)
+
+   ! Sum the distances outside the benchmarked function
    benchmark_result%result = sum(distances)
 
    call format_results(benchmark_result, result_str)
@@ -33,132 +35,132 @@ program main
    contains
 
       integer(8) function benchmark_function()
-      implicit none
-      integer :: i, j, idx
-      integer(8) :: sum_distances
-      sum_distances = 0
-      idx = 1
-      do i = 1, size(args)
-         do j = i + 1, size(args)
-            distances(idx) = levenshtein_distance(trim(args(i)), trim(args(j)))
-            sum_distances = sum_distances + distances(idx)
-            idx = idx + 1
+         implicit none
+         integer :: i, j, idx
+         integer(8) :: sum_distances
+         sum_distances = 0
+         idx = 1
+         do i = 1, size(args)
+            do j = i + 1, size(args)
+               distances(idx) = levenshtein_distance(trim(args(i)), trim(args(j)))
+               sum_distances = sum_distances + distances(idx)
+               idx = idx + 1
+            end do
          end do
-      end do
-      benchmark_function = sum_distances
-   end function benchmark_function
+         benchmark_function = sum_distances
+      end function benchmark_function
 
-   subroutine read_all_words(filename, all_words, iostat)
-      implicit none
-      character(len = *), intent(in) :: filename
-      character(len = :), allocatable, intent(out) :: all_words(:)
-      integer, intent(out) :: iostat
-      integer :: unit, num_words, i
-      integer, parameter :: max_len = 10000 ! Allow for really long words
-      character(len = max_len) :: word
+      subroutine read_all_words(filename, all_words, iostat)
+         implicit none
+         character(len = *), intent(in) :: filename
+         character(len = :), allocatable, intent(out) :: all_words(:)
+         integer, intent(out) :: iostat
+         integer :: unit, num_words, i
+         integer, parameter :: max_len = 10000 ! Allow for really long words
+         character(len = max_len) :: word
 
-      open(newunit = unit, file = filename, status = 'old', action = 'read', iostat = iostat)
-      if (iostat /= 0) return
+         open(newunit = unit, file = filename, status = 'old', action = 'read', iostat = iostat)
+         if (iostat /= 0) return
 
-      num_words = 0
-      do
-         read(unit, '(A)', iostat = iostat) word
-         if (iostat /= 0) exit
-         num_words = num_words + 1
-      end do
-
-      if (num_words > 0) then
-         allocate(character(len = max_len) :: all_words(num_words))
-         rewind(unit)
-         do i = 1, num_words
-            read(unit, '(A)', iostat = iostat) all_words(i)
+         num_words = 0
+         do
+            read(unit, '(A)', iostat = iostat) word
             if (iostat /= 0) exit
-         end do
-      else
-         allocate(all_words, mold = [character(len = max_len) :: ''])
-      end if
-
-      close(unit)
-   end subroutine read_all_words
-
-   ! Calculates the Levenshtein distance between two strings using Wagner-Fischer algorithm
-   ! Space Complexity: O(min(m,n)) - only uses two arrays instead of full matrix
-   ! Time Complexity: O(m*n) where m and n are the lengths of the input strings
-   function levenshtein_distance(s1, s2) result(distance)
-      character(len = *), intent(in) :: s1, s2
-      integer :: distance
-
-      integer :: m, n, i, j, cost
-      integer, allocatable :: prev_row(:), curr_row(:)
-      character(len = 1) :: c1, c2
-      character(len = :), allocatable :: str1, str2
-
-      ! Early termination checks
-      if (s1 == s2) then
-         distance = 0
-         return
-      end if
-
-      if (len_trim(s1) == 0) then
-         distance = len_trim(s2)
-         return
-      end if
-
-      if (len_trim(s2) == 0) then
-         distance = len_trim(s1)
-         return
-      end if
-
-      ! Make s1 the shorter string for space optimization
-      if (len_trim(s1) > len_trim(s2)) then
-         str1 = trim(s2)
-         str2 = trim(s1)
-      else
-         str1 = trim(s1)
-         str2 = trim(s2)
-      end if
-
-      m = len_trim(str1)
-      n = len_trim(str2)
-
-      ! Use two arrays instead of full matrix for space optimization
-      allocate(prev_row(0:m), curr_row(0:m))
-
-      ! Initialize first row
-      do i = 0, m
-         prev_row(i) = i
-      end do
-
-      ! Main computation loop
-      do j = 1, n
-         curr_row(0) = j
-
-         do i = 1, m
-            ! Get characters at current position
-            c1 = str1(i:i)
-            c2 = str2(j:j)
-
-            ! Calculate cost
-            if (c1 == c2) then
-               cost = 0
-            else
-               cost = 1
-            end if
-
-            ! Calculate minimum of three operations
-            curr_row(i) = min(prev_row(i) + 1, & ! deletion
-            curr_row(i - 1) + 1, & ! insertion
-            prev_row(i - 1) + cost)     ! substitution
+            num_words = num_words + 1
          end do
 
-         ! Swap rows
-         prev_row = curr_row
-      end do
+         if (num_words > 0) then
+            allocate(character(len = max_len) :: all_words(num_words))
+            rewind(unit)
+            do i = 1, num_words
+               read(unit, '(A)', iostat = iostat) all_words(i)
+               if (iostat /= 0) exit
+            end do
+         else
+            allocate(all_words, mold = [character(len = max_len) :: ''])
+         end if
 
-      distance = prev_row(m)
+         close(unit)
+      end subroutine read_all_words
 
-      ! Clean up
-      deallocate(prev_row, curr_row)
-   end function levenshtein_distance
+      ! Calculates the Levenshtein distance between two strings using Wagner-Fischer algorithm
+      ! Space Complexity: O(min(m,n)) - only uses two arrays instead of full matrix
+      ! Time Complexity: O(m*n) where m and n are the lengths of the input strings
+      function levenshtein_distance(s1, s2) result(distance)
+         character(len = *), intent(in) :: s1, s2
+         integer :: distance
 
-end program main
+         integer :: m, n, i, j, cost
+         integer, allocatable :: prev_row(:), curr_row(:)
+         character(len = 1) :: c1, c2
+         character(len = :), allocatable :: str1, str2
+
+         ! Early termination checks
+         if (s1 == s2) then
+            distance = 0
+            return
+         end if
+
+         if (len_trim(s1) == 0) then
+            distance = len_trim(s2)
+            return
+         end if
+
+         if (len_trim(s2) == 0) then
+            distance = len_trim(s1)
+            return
+         end if
+
+         ! Make s1 the shorter string for space optimization
+         if (len_trim(s1) > len_trim(s2)) then
+            str1 = trim(s2)
+            str2 = trim(s1)
+         else
+            str1 = trim(s1)
+            str2 = trim(s2)
+         end if
+
+         m = len_trim(str1)
+         n = len_trim(str2)
+
+         ! Use two arrays instead of full matrix for space optimization
+         allocate(prev_row(0:m), curr_row(0:m))
+
+         ! Initialize first row
+         do i = 0, m
+            prev_row(i) = i
+         end do
+
+         ! Main computation loop
+         do j = 1, n
+            curr_row(0) = j
+
+            do i = 1, m
+               ! Get characters at current position
+               c1 = str1(i:i)
+               c2 = str2(j:j)
+
+               ! Calculate cost
+               if (c1 == c2) then
+                  cost = 0
+               else
+                  cost = 1
+               end if
+
+               ! Calculate minimum of three operations
+               curr_row(i) = min(prev_row(i) + 1, & ! deletion
+               curr_row(i - 1) + 1, &               ! insertion
+               prev_row(i - 1) + cost)              ! substitution
+            end do
+
+            ! Swap rows
+            prev_row = curr_row
+         end do
+
+         distance = prev_row(m)
+
+         ! Clean up
+         deallocate(prev_row, curr_row)
+      end function levenshtein_distance
+
+   end program main

--- a/lib/fortran/benchmark.f90
+++ b/lib/fortran/benchmark.f90
@@ -49,8 +49,8 @@ contains
     call system_clock(last_status_t)
 
     if (print_status) then
-      write(*, '(A)', advance='no') "."
-      flush(6)
+      write(0, '(A)', advance='no') "."
+      flush(0)
     end if
 
     do while (total_elapsed_time < run_ms * 1.0e6)
@@ -65,13 +65,13 @@ contains
       if (elapsed_times(count) > max_time) max_time = elapsed_times(count)
       if (print_status .and. (end_time - last_status_t) > 1000000000) then
         last_status_t = end_time
-        write(*, '(A)', advance='no') "."
-        flush(6)
+        write(0, '(A)', advance='no') "."
+        flush(0)
       end if
     end do
 
     if (print_status) then
-      write(*, '(A)') ""
+      write(0, '(A)') ""
     end if
 
     mean = sum(elapsed_times(1:count)) / count
@@ -86,11 +86,15 @@ contains
   end subroutine run
 
   subroutine format_results(benchmark_result, result_str)
-    implicit none
-    type(benchmark_result_t), intent(in) :: benchmark_result
-    character(len=256), intent(out) :: result_str
-    write(result_str, '(f6.3,1x,f6.3,1x,f6.3,1x,f6.3,1x,i0,1x,i8)') &
-      benchmark_result%mean_ms, benchmark_result%std_dev_ms, benchmark_result%min_ms, benchmark_result%max_ms, benchmark_result%runs, benchmark_result%result
+      implicit none
+      type(benchmark_result_t), intent(in) :: benchmark_result
+      character(len=:), allocatable, intent(out) :: result_str
+      character(len=256) :: temp_str
+
+      write(temp_str, '(f0.6,",",f0.6,",",f0.6,",",f0.6,",",i0,",",i0)') &
+        benchmark_result%mean_ms, benchmark_result%std_dev_ms, benchmark_result%min_ms, benchmark_result%max_ms, benchmark_result%runs, benchmark_result%result
+
+      result_str = trim(adjustl(temp_str))
   end subroutine format_results
 
 end module benchmark

--- a/lib/fortran/benchmark.f90
+++ b/lib/fortran/benchmark.f90
@@ -1,0 +1,67 @@
+module benchmark
+  implicit none
+  private
+  public :: run, format_results, benchmark_result_t  ! Make benchmark_result_t public
+
+  type :: benchmark_result_t
+    integer :: runs
+    real(8) :: mean_ms
+    real(8) :: std_dev_ms
+    real(8) :: min_ms
+    real(8) :: max_ms
+    integer(8) :: result
+  end type benchmark_result_t
+
+contains
+
+  subroutine run(f, run_ms, result)
+    implicit none
+    interface
+      integer(8) function f()
+      end function f
+    end interface
+    procedure(f), pointer :: func_ptr
+    integer, intent(in) :: run_ms
+    type(benchmark_result_t), intent(out) :: result
+    integer(8) :: start_time, end_time, elapsed_time, total_elapsed_time
+    integer :: count
+    real(8) :: elapsed_times(1000), mean, variance, std_dev, min_time, max_time
+
+    func_ptr => f
+    total_elapsed_time = 0
+    count = 0
+    min_time = 1.0e12
+    max_time = 0.0
+
+    do while (total_elapsed_time < run_ms * 1.0e6)
+      call system_clock(start_time)
+      result%result = func_ptr()
+      call system_clock(end_time)
+      elapsed_time = end_time - start_time
+      elapsed_times(count + 1) = elapsed_time / 1.0e6
+      total_elapsed_time = total_elapsed_time + elapsed_time
+      count = count + 1
+      if (elapsed_times(count) < min_time) min_time = elapsed_times(count)
+      if (elapsed_times(count) > max_time) max_time = elapsed_times(count)
+    end do
+
+    mean = sum(elapsed_times(1:count)) / count
+    variance = sum((elapsed_times(1:count) - mean)**2) / count
+    std_dev = sqrt(variance)
+
+    result%runs = count
+    result%mean_ms = mean
+    result%std_dev_ms = std_dev
+    result%min_ms = min_time
+    result%max_ms = max_time
+  end subroutine run
+
+  subroutine format_results(benchmark_result, result_str)
+    implicit none
+    type(benchmark_result_t), intent(in) :: benchmark_result
+    character(len=256), intent(out) :: result_str
+    write(result_str, '(f6.3,1x,f6.3,1x,f6.3,1x,f6.3,1x,i0,1x,i8)') &
+      benchmark_result%mean_ms, benchmark_result%std_dev_ms, benchmark_result%min_ms, benchmark_result%max_ms, benchmark_result%runs, benchmark_result%result
+  end subroutine format_results
+
+end module benchmark

--- a/loops/fortran/run.f90
+++ b/loops/fortran/run.f90
@@ -1,0 +1,47 @@
+program main
+    use benchmark
+    implicit none
+    integer :: run_ms, warmup_ms, u
+    character(len=256) :: arg
+    type(benchmark_result_t) :: warmup_result, benchmark_result
+    character(len = :), allocatable :: result_str
+
+    call get_command_argument(1, arg)
+    read(arg, *) run_ms                 ! Convert the command-line argument to integer
+    call get_command_argument(2, arg)
+    read(arg, *) warmup_ms              ! Convert the command-line argument to integer
+    call get_command_argument(3, arg)
+    read(arg, *) u                      ! Convert the command-line argument to integer
+
+    call run(loops_benchmark, warmup_ms, warmup_result)
+    call run(loops_benchmark, run_ms, benchmark_result)
+
+    call format_results(benchmark_result, result_str)
+    write(*, '(A)') trim(adjustl(result_str))
+
+contains
+
+    integer(8) function loops_benchmark()
+        implicit none
+        integer :: i, j, r
+        integer(8) :: result
+        integer, dimension(10000) :: a
+        real :: random_value
+
+        call random_seed()                  ! Initialize the random number generator
+        call random_number(random_value)    ! Generate a random number (0 <= random_value < 1)
+        r = int(random_value * 10000)       ! Scale and convert to an integer
+
+        a = 0                               ! Initialize the array with zeros    
+        do i = 1, 10000
+            do j = 0, 9999
+                a(i) = a(i) + mod(j, u)
+            end do
+            a(i) = a(i) + r
+        end do
+
+        result = a(r)
+        loops_benchmark = result
+    end function loops_benchmark
+
+end program main

--- a/run.sh
+++ b/run.sh
@@ -154,6 +154,7 @@ run "Babashka" "bb/run.clj" "bb bb/run.clj"
 run "C" "./c/run" "./c/run"
 run "Clojure" "./clojure/classes/run.class" "java -cp clojure/classes:$(clojure -Spath) run"
 run "Clojure Native" "./clojure-native-image/run" "./clojure-native-image/run"
+run "Fortran" "./fortran/run" "./fortran/run"
 run "Java" "./jvm/run.class" "java -cp .:../lib/java jvm.run"
 run "Java Native" "./java-native-image/run" "./java-native-image/run"
 ####### END The languages


### PR DESCRIPTION
I have:

* [x] Read the project [README](../README.md), including the [benchmark descriptions](../README.md#available-benchmarks)
* [x] Read the PR template instructions before I deleted them
* [x] Understood that if I have changed something that could impact performance of one or more contributions, I should provide results benchmark runs, using the `run.sh` script, from before and after the change.

## Description of changes

This adds Fortran to the list of languages ported to the new in-process runner.

* Fixes: #372

Benchmark results:

* https://pez.github.io/languages-visualizations/#https://gist.github.com/PEZ/411e2da1af3bbe21c4ad1d626451ec1d

(Select the M4 Max run from the dropdown.)

The raw CSV:

```
benchmark,timestamp,commit_sha,is_checked,user,model,ram,os,arch,language,run_ms,mean_ms,std-dev-ms,min_ms,max_ms,runs
loops,2025-01-25T22:34:12Z,fdbd28c,true,PEZ,Apple M4 Max,64GB,darwin24,arm64,Babashka,10000,4932.429097333333,19.558807582136737,4904.777583,4946.859625,3
loops,2025-01-25T22:34:12Z,fdbd28c,true,PEZ,Apple M4 Max,64GB,darwin24,arm64,C,10000,49.626525,1.197406,47.808000,53.878000,202
loops,2025-01-25T22:34:12Z,fdbd28c,true,PEZ,Apple M4 Max,64GB,darwin24,arm64,Clojure,10000,49.86259725870647,10.513245406417887,47.251917,197.52725,201
loops,2025-01-25T22:34:12Z,fdbd28c,true,PEZ,Apple M4 Max,64GB,darwin24,arm64,Clojure Native,10000,49.84420378606965,1.0570703469045586,48.031167,54.965,201
loops,2025-01-25T22:34:12Z,fdbd28c,true,PEZ,Apple M4 Max,64GB,darwin24,arm64,Fortran,10000,49.843781,1.148286,48.014000,54.348000,201
loops,2025-01-25T22:34:12Z,fdbd28c,true,PEZ,Apple M4 Max,64GB,darwin24,arm64,Java,10000,49.104576,1.066798,47.233708,53.500709,204
loops,2025-01-25T22:34:12Z,fdbd28c,true,PEZ,Apple M4 Max,64GB,darwin24,arm64,Java Native,10000,50.052993,0.940394,48.424709,54.072500,200

benchmark,timestamp,commit_sha,is_checked,user,model,ram,os,arch,language,run_ms,mean_ms,std-dev-ms,min_ms,max_ms,runs
hello-world,2025-01-25T22:39:15Z,fdbd28c,true,PEZ,Apple M4 Max,64GB,darwin24,arm64,Babashka,10000,10.8032,0.644375,9.66471,11.7805,25
hello-world,2025-01-25T22:39:15Z,fdbd28c,true,PEZ,Apple M4 Max,64GB,darwin24,arm64,C,10000,2.1302,0.313791,1.76792,2.88833,25
hello-world,2025-01-25T22:39:15Z,fdbd28c,true,PEZ,Apple M4 Max,64GB,darwin24,arm64,Clojure,10000,312.343,3.31949,304.985,319.047,25
hello-world,2025-01-25T22:39:15Z,fdbd28c,true,PEZ,Apple M4 Max,64GB,darwin24,arm64,Clojure Native,10000,4.98707,0.612648,4.14313,6.39454,25
hello-world,2025-01-25T22:39:15Z,fdbd28c,true,PEZ,Apple M4 Max,64GB,darwin24,arm64,Fortran,10000,3.16003,0.382805,2.54942,3.84154,25
hello-world,2025-01-25T22:39:15Z,fdbd28c,true,PEZ,Apple M4 Max,64GB,darwin24,arm64,Java,10000,48.1888,2.65731,45.5346,57.1655,25
hello-world,2025-01-25T22:39:15Z,fdbd28c,true,PEZ,Apple M4 Max,64GB,darwin24,arm64,Java Native,10000,4.73181,0.600208,3.78654,6.04833,25

benchmark,timestamp,commit_sha,is_checked,user,model,ram,os,arch,language,run_ms,mean_ms,std-dev-ms,min_ms,max_ms,runs
fibonacci,2025-01-25T22:31:34Z,fdbd28c,true,PEZ,Apple M4 Max,64GB,darwin24,arm64,Babashka,10000,4208.603403,16.693095493461023,4185.345667,4223.739042,3
fibonacci,2025-01-25T22:31:34Z,fdbd28c,true,PEZ,Apple M4 Max,64GB,darwin24,arm64,C,10000,25.253205,0.621768,24.369000,27.912000,396
fibonacci,2025-01-25T22:31:34Z,fdbd28c,true,PEZ,Apple M4 Max,64GB,darwin24,arm64,Clojure,10000,47.03717979812207,1.3824813318915894,44.573166,50.967541,213
fibonacci,2025-01-25T22:31:34Z,fdbd28c,true,PEZ,Apple M4 Max,64GB,darwin24,arm64,Clojure Native,10000,43.46573142857143,1.216267624512897,41.035125,48.560542,231
fibonacci,2025-01-25T22:31:34Z,fdbd28c,true,PEZ,Apple M4 Max,64GB,darwin24,arm64,Fortran,10000,.124543,.024082,.103000,1.581000,80294
fibonacci,2025-01-25T22:31:34Z,fdbd28c,true,PEZ,Apple M4 Max,64GB,darwin24,arm64,Java,10000,42.044485,1.212892,39.179459,47.019875,238
fibonacci,2025-01-25T22:31:34Z,fdbd28c,true,PEZ,Apple M4 Max,64GB,darwin24,arm64,Java Native,10000,38.524551,1.014170,36.684375,42.212000,260

benchmark,timestamp,commit_sha,is_checked,user,model,ram,os,arch,language,run_ms,mean_ms,std-dev-ms,min_ms,max_ms,runs
levenshtein,2025-01-25T22:36:38Z,fdbd28c,true,PEZ,Apple M4 Max,64GB,darwin24,arm64,Babashka,10000,23214.701,0.0,23214.701,23214.701,1
levenshtein,2025-01-25T22:36:38Z,fdbd28c,true,PEZ,Apple M4 Max,64GB,darwin24,arm64,C,10000,31.673044,0.602644,30.624000,34.882000,316
levenshtein,2025-01-25T22:36:38Z,fdbd28c,true,PEZ,Apple M4 Max,64GB,darwin24,arm64,Clojure,10000,56.42315778651685,1.0903235486343315,55.100291,61.138917,178
levenshtein,2025-01-25T22:36:38Z,fdbd28c,true,PEZ,Apple M4 Max,64GB,darwin24,arm64,Clojure Native,10000,60.27484936746988,1.401040380520535,58.32725,68.93675,166
levenshtein,2025-01-25T22:36:38Z,fdbd28c,true,PEZ,Apple M4 Max,64GB,darwin24,arm64,Fortran,10000,33.700690,.888740,32.598000,42.921001,297
levenshtein,2025-01-25T22:36:38Z,fdbd28c,true,PEZ,Apple M4 Max,64GB,darwin24,arm64,Java,10000,54.696480,1.600836,51.650167,59.846041,183
levenshtein,2025-01-25T22:36:38Z,fdbd28c,true,PEZ,Apple M4 Max,64GB,darwin24,arm64,Java Native,10000,61.097392,4.235434,52.652875,73.485792,164
```
