### PR TITLE
Zig: Add in-process benchmark utility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ code.jar
 code.elc
 code.eln
 Cargo.lock
+.zig-cache
+zig-out
 **/csharp/bin/
 **/csharp/obj/
 **/fsharp/bin/

--- a/clean.sh
+++ b/clean.sh
@@ -21,7 +21,7 @@ rm d/code
 rm odin/code
 rm objc/code
 rm fortran/code
-rm zig/code
+rm -rf zig/{code,code.o} zig/{.zig-cache,zig-out}
 rm lua/code
 rm -f swift/code
 rm haxe/code.jar

--- a/compile.sh
+++ b/compile.sh
@@ -49,7 +49,7 @@ function compile {
 echo "Starting compiles for ${benchmark}"
 
 # Please keep in language name alphabetic order
-# run "Language name" "File that should exist" "Command line"
+# run "Language name" "Directory that should exist" "Command line"
 ####### BEGIN The languages
 compile 'C' 'c' 'gcc -O3 -I../lib/c -c ../lib/c/benchmark.c -o c/benchmark.o && gcc -O3 -I../lib/c c/benchmark.o c/run.c -o c/run -lm'
 compile 'Clojure' 'clojure' '(cd clojure && mkdir -p classes && clojure -M -e "(compile (quote run))")'
@@ -58,6 +58,7 @@ compile 'C++' 'cpp' 'g++ -march=native -std=c++23 -O3 -Ofast -I../lib/cpp cpp/ru
 compile 'Java' 'jvm' 'javac -cp ../lib/java jvm/run.java'
 compile 'Java Native' 'java-native-image' "(cd java-native-image ; native-image -cp ..:../../lib/java --no-fallback -O3 --pgo-instrument -march=native jvm.run) && ./java-native-image/jvm.run -XX:ProfilesDumpFile=java-native-image/run.iprof 10000 2000 $(./check-output.sh -i) && (cd java-native-image ; native-image -cp ..:../../lib/java -O3 --pgo=run.iprof -march=native jvm.run -o run)"
 compile 'Fortran' 'fortran' "gfortran -O3 -J../lib/fortran ../lib/fortran/benchmark.f90 fortran/run.f90 -o fortran/run"
+compile 'Zig' 'zig' 'zig build --build-file zig/build.zig --prefix ${PWD}/zig/zig-out --cache-dir ${PWD}/zig/.zig-cache --release=fast'
 
 ####### END The languages
 

--- a/fibonacci/zig/build.zig
+++ b/fibonacci/zig/build.zig
@@ -1,0 +1,60 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    // Resolve target triplet of "cpu-os-abi" (native is default)
+    const target = b.standardTargetOptions(.{});
+
+    // Resolve optimization mode (debug is default)
+    const optimize = b.standardOptimizeOption(.{});
+
+    // Modules declaration
+    const benchmark = b.createModule(.{ .root_source_file = b.path("../../lib/zig/benchmark.zig") });
+    // const submod = b.createModule(.{ .root_source_file = b.path("src/submod/mod.zig") });
+
+    const exe = b.addExecutable(.{
+        .name = "run",
+        .root_source_file = b.path("run.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    exe.root_module.addImport("benchmark", benchmark);
+    // submod.addImport("benchmark", benchmark);
+
+    b.installArtifact(exe);
+
+    // This *creates* a Run step in the build graph, to be executed when another
+    // step is evaluated that depends on it. The next line below will establish
+    // such run a dependency.
+    const run_cmd = b.addRunArtifact(exe);
+    run_cmd.step.dependOn(b.getInstallStep());
+
+    // This allows the user to pass arguments to the application in the build
+    // command itself, like this: `zig build run -- arg1 arg2 etc`
+    if (b.args) |args| {
+        run_cmd.addArgs(args);
+    }
+
+    // This creates a build step. It will be visible in the `zig build --help` menu,
+    // and can be selected like this: `zig build run`
+    // This will evaluate the `run` step rather than the default, which is "install".
+    const run_step = b.step("run", "Run the application");
+    run_step.dependOn(&run_cmd.step);
+
+    const unit_tests = b.addTest(.{
+        .root_source_file = b.path("run.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    unit_tests.root_module.addImport("benchmark", benchmark);
+    // unit_tests.root_module.addImport("submod", submod);
+
+    const run_unit_tests = b.addRunArtifact(unit_tests);
+
+    // Similar to creating the run step earlier, this exposes a `test` step to
+    // the `zig build --help` menu, providing a way for the user to request
+    // running the unit tests.
+    const test_step = b.step("test", "Run unit tests");
+    test_step.dependOn(&run_unit_tests.step);
+}

--- a/fibonacci/zig/code.zig
+++ b/fibonacci/zig/code.zig
@@ -1,23 +1,30 @@
 const std = @import("std");
-const stdout = std.io.getStdOut().writer();
 
-fn fib(n: u64) u64 {
-    return switch (n) {
-        0 => 0,
-        1 => 1,
-        else => fib(n - 1) + fib(n - 2),
-    };
-}
+const fibonacci = @import("./fibonacci.zig").fibonacci;
 
 pub fn main() !void {
-    var args = std.process.args();
-    _ = args.next() orelse unreachable; // skip first, which is program name
-    const arg = args.next() orelse unreachable;
-    const u = try std.fmt.parseInt(usize, arg, 10);
+    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
 
-    var r: u64 = 0;
-    for (1..u) |i| {
-        r += fib(i);
+    const args_cli = try std.process.argsAlloc(allocator);
+
+    if (args_cli.len < 2) {
+        const stderr = std.io.getStdErr().writer();
+        try stderr.writeAll("Please provide a number as argument.\n");
+        std.process.exit(1);
     }
-    try stdout.print("{d}\n", .{r});
+
+    const args = args_cli[1..];
+
+    const runs = try std.fmt.parseInt(usize, args[0], 0);
+
+    var sum: usize = 0;
+
+    for (0..runs) |i| {
+        sum += fibonacci(i);
+    }
+
+    const stdout = std.io.getStdOut().writer();
+    try stdout.print("{d}\n", .{sum});
 }

--- a/fibonacci/zig/fibonacci.zig
+++ b/fibonacci/zig/fibonacci.zig
@@ -1,0 +1,6 @@
+pub fn fibonacci(n: usize) usize {
+    return switch (n) {
+        0...1 => n,
+        else => fibonacci(n - 1) + fibonacci(n - 2),
+    };
+}

--- a/fibonacci/zig/run.zig
+++ b/fibonacci/zig/run.zig
@@ -1,0 +1,26 @@
+const std = @import("std");
+
+const benchmark = @import("benchmark");
+const fibonacci = @import("./fibonacci.zig").fibonacci;
+
+pub fn main() !void {
+    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    // retrieve arguments for benchmark, contains program arguments
+    const args = try benchmark.loadArguments(allocator);
+
+    // parse program arguments
+    const number: usize = try std.fmt.parseInt(usize, args.program_args[0], 0);
+
+    // perform full benchmark
+    const context = benchmark.createContext(fibonacci);
+    const stats = (try context.benchmark(allocator, args.warmup_ms, args.run_ms, .{number})).?;
+
+    // get last result for success checks
+    const last_result = stats.lastResult();
+
+    // output results
+    try stats.printOutput(allocator, last_result);
+}

--- a/hello-world/zig/build.zig
+++ b/hello-world/zig/build.zig
@@ -1,0 +1,60 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    // Resolve target triplet of "cpu-os-abi" (native is default)
+    const target = b.standardTargetOptions(.{});
+
+    // Resolve optimization mode (debug is default)
+    const optimize = b.standardOptimizeOption(.{});
+
+    // Modules declaration
+    const benchmark = b.createModule(.{ .root_source_file = b.path("../../lib/zig/benchmark.zig") });
+    // const submod = b.createModule(.{ .root_source_file = b.path("src/submod/mod.zig") });
+
+    const exe = b.addExecutable(.{
+        .name = "run",
+        .root_source_file = b.path("run.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    exe.root_module.addImport("benchmark", benchmark);
+    // submod.addImport("benchmark", benchmark);
+
+    b.installArtifact(exe);
+
+    // This *creates* a Run step in the build graph, to be executed when another
+    // step is evaluated that depends on it. The next line below will establish
+    // such run a dependency.
+    const run_cmd = b.addRunArtifact(exe);
+    run_cmd.step.dependOn(b.getInstallStep());
+
+    // This allows the user to pass arguments to the application in the build
+    // command itself, like this: `zig build run -- arg1 arg2 etc`
+    if (b.args) |args| {
+        run_cmd.addArgs(args);
+    }
+
+    // This creates a build step. It will be visible in the `zig build --help` menu,
+    // and can be selected like this: `zig build run`
+    // This will evaluate the `run` step rather than the default, which is "install".
+    const run_step = b.step("run", "Run the application");
+    run_step.dependOn(&run_cmd.step);
+
+    const unit_tests = b.addTest(.{
+        .root_source_file = b.path("run.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    unit_tests.root_module.addImport("benchmark", benchmark);
+    // unit_tests.root_module.addImport("submod", submod);
+
+    const run_unit_tests = b.addRunArtifact(unit_tests);
+
+    // Similar to creating the run step earlier, this exposes a `test` step to
+    // the `zig build --help` menu, providing a way for the user to request
+    // running the unit tests.
+    const test_step = b.step("test", "Run unit tests");
+    test_step.dependOn(&run_unit_tests.step);
+}

--- a/hello-world/zig/run.zig
+++ b/hello-world/zig/run.zig
@@ -1,0 +1,6 @@
+const std = @import("std");
+
+pub fn main() !void {
+    const stdout = std.io.getStdOut().writer();
+    try stdout.writeAll("Hello, World!\n");
+}

--- a/levenshtein/zig/build.zig
+++ b/levenshtein/zig/build.zig
@@ -1,0 +1,60 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    // Resolve target triplet of "cpu-os-abi" (native is default)
+    const target = b.standardTargetOptions(.{});
+
+    // Resolve optimization mode (debug is default)
+    const optimize = b.standardOptimizeOption(.{});
+
+    // Modules declaration
+    const benchmark = b.createModule(.{ .root_source_file = b.path("../../lib/zig/benchmark.zig") });
+    // const submod = b.createModule(.{ .root_source_file = b.path("src/submod/mod.zig") });
+
+    const exe = b.addExecutable(.{
+        .name = "run",
+        .root_source_file = b.path("run.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    exe.root_module.addImport("benchmark", benchmark);
+    // submod.addImport("benchmark", benchmark);
+
+    b.installArtifact(exe);
+
+    // This *creates* a Run step in the build graph, to be executed when another
+    // step is evaluated that depends on it. The next line below will establish
+    // such run a dependency.
+    const run_cmd = b.addRunArtifact(exe);
+    run_cmd.step.dependOn(b.getInstallStep());
+
+    // This allows the user to pass arguments to the application in the build
+    // command itself, like this: `zig build run -- arg1 arg2 etc`
+    if (b.args) |args| {
+        run_cmd.addArgs(args);
+    }
+
+    // This creates a build step. It will be visible in the `zig build --help` menu,
+    // and can be selected like this: `zig build run`
+    // This will evaluate the `run` step rather than the default, which is "install".
+    const run_step = b.step("run", "Run the application");
+    run_step.dependOn(&run_cmd.step);
+
+    const unit_tests = b.addTest(.{
+        .root_source_file = b.path("run.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    unit_tests.root_module.addImport("benchmark", benchmark);
+    // unit_tests.root_module.addImport("submod", submod);
+
+    const run_unit_tests = b.addRunArtifact(unit_tests);
+
+    // Similar to creating the run step earlier, this exposes a `test` step to
+    // the `zig build --help` menu, providing a way for the user to request
+    // running the unit tests.
+    const test_step = b.step("test", "Run unit tests");
+    test_step.dependOn(&run_unit_tests.step);
+}

--- a/levenshtein/zig/code.zig
+++ b/levenshtein/zig/code.zig
@@ -1,55 +1,6 @@
 const std = @import("std");
 
-/// Calculates the Levenshtein distance between two strings using Wagner-Fischer algorithm
-/// Space Complexity: O(min(m,n)) - only uses two arrays instead of full matrix
-/// Time Complexity: O(m*n) where m and n are the lengths of the input strings
-fn levenshteinDistance(s1: *const []const u8, s2: *const []const u8, buffer: *const []usize) usize {
-    // Early termination checks
-    if (std.mem.eql(u8, s1.*, s2.*)) return 0;
-    if (s1.*.len == 0) return s2.*.len;
-    if (s2.*.len == 0) return s1.*.len;
-
-    // Make s1 the shorter string for space optimization
-    const str1, const str2 = init: {
-        if (s1.*.len > s2.*.len) {
-            break :init .{ s2.*, s1.* };
-        }
-
-        break :init .{ s1.*, s2.* };
-    };
-
-    const m = str1.len;
-    const n = str2.len;
-
-    var prev_row = buffer.*[0..(m + 1)];
-    var curr_row = buffer.*[(m + 1)..];
-
-    // Initialize first row
-    for (0..m + 1) |i| {
-        prev_row[i] = i;
-    }
-
-    // Main computation loop
-    for (str2, 0..n) |ch2, j| {
-        curr_row[0] = j + 1;
-
-        for (str1, 0..m) |ch1, i| {
-            const cost: usize = @intFromBool(ch1 != ch2);
-
-            // Calculate minimum of three operations
-            curr_row[i + 1] = @min(
-                prev_row[i + 1] + 1, // deletion
-                curr_row[i] + 1, // insertion
-                prev_row[i] + cost, // substitution
-            );
-        }
-
-        // Swap rows
-        std.mem.swap([]usize, &prev_row, &curr_row);
-    }
-
-    return prev_row[m];
-}
+const levenshteinDistance = @import("./levenshtein.zig").levenshteinDistance;
 
 pub fn main() !void {
     var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);

--- a/levenshtein/zig/levenshtein.zig
+++ b/levenshtein/zig/levenshtein.zig
@@ -1,0 +1,51 @@
+const std = @import("std");
+
+/// Calculates the Levenshtein distance between two strings using Wagner-Fischer algorithm
+/// Space Complexity: O(min(m,n)) - only uses two arrays instead of full matrix
+/// Time Complexity: O(m*n) where m and n are the lengths of the input strings
+pub fn levenshteinDistance(s1: *const []const u8, s2: *const []const u8, buffer: *const []usize) usize {
+    // Early termination checks
+    if (s1.*.len == 0) return s2.*.len;
+    if (s2.*.len == 0) return s1.*.len;
+
+    // Make s1 the shorter string for space optimization
+    const str1, const str2 = init: {
+        if (s1.*.len > s2.*.len) {
+            break :init .{ s2.*, s1.* };
+        }
+
+        break :init .{ s1.*, s2.* };
+    };
+
+    const m = str1.len;
+    const n = str2.len;
+
+    var prev_row = buffer.*[0..(m + 1)];
+    var curr_row = buffer.*[(m + 1)..];
+
+    // Initialize first row
+    for (0..m + 1) |i| {
+        prev_row[i] = i;
+    }
+
+    // Main computation loop
+    for (str2, 0..n) |ch2, j| {
+        curr_row[0] = j + 1;
+
+        for (str1, 0..m) |ch1, i| {
+            const cost: usize = @intFromBool(ch1 != ch2);
+
+            // Calculate minimum of three operations
+            curr_row[i + 1] = @min(
+                prev_row[i + 1] + 1, // deletion
+                curr_row[i] + 1, // insertion
+                prev_row[i] + cost, // substitution
+            );
+        }
+
+        // Swap rows
+        std.mem.swap([]usize, &prev_row, &curr_row);
+    }
+
+    return prev_row[m];
+}

--- a/levenshtein/zig/run.zig
+++ b/levenshtein/zig/run.zig
@@ -1,0 +1,62 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+const benchmark = @import("benchmark");
+const levenshteinDistance = @import("./levenshtein.zig").levenshteinDistance;
+
+fn calculateDistances(allocator: Allocator, word_list: *const std.ArrayList([]const u8), buffer: *const []usize) !std.ArrayList(usize) {
+    var results = try std.ArrayList(usize).initCapacity(allocator, (word_list.items.len * (word_list.items.len - 1)) / 2);
+
+    const second_last_index = word_list.items.len - 1;
+
+    for (word_list.items[0..second_last_index], 0..second_last_index) |wordA, i| {
+        // rest of words in list for comparison
+        const cmp_words = word_list.items[(i + 1)..];
+
+        for (cmp_words, 0..cmp_words.len) |wordB, _| {
+            const distance = levenshteinDistance(&wordA, &wordB, buffer);
+            try results.append(distance);
+        }
+    }
+
+    return results;
+}
+
+pub fn main() !void {
+    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    // retrieve arguments for benchmark, contains program arguments
+    const args = try benchmark.loadArguments(allocator);
+
+    // parse program arguments
+    const word_list = try benchmark.fileReadLines(allocator, args.program_args[0]);
+
+    // calculate length of longest input string
+    var max_inp_len: usize = 0;
+
+    for (word_list.items) |word| {
+        max_inp_len = @max(max_inp_len, word.len);
+    }
+
+    // reuse buffer for prev_row and curr_row to minimize allocations
+    const buffer = try allocator.alloc(usize, (max_inp_len + 1) * 2);
+
+    // perform full benchmark
+    const context = benchmark.createContext(calculateDistances);
+    const stats = (try context.benchmark(allocator, args.warmup_ms, args.run_ms, .{ allocator, &word_list, &buffer })).?;
+
+    // get last result for success checks
+    const last_result = stats.lastResult();
+
+    // sum the distances outside the benchmarked function
+    var sum: usize = 0;
+
+    for ((try last_result).items) |distance| {
+        sum += distance;
+    }
+
+    // output results
+    try stats.printOutput(allocator, sum);
+}

--- a/lib/zig/benchmark.zig
+++ b/lib/zig/benchmark.zig
@@ -1,0 +1,237 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const nanoTimestamp = std.time.nanoTimestamp;
+
+const INITIAL_CAPACITY: usize = 1_000;
+
+pub const ArgumentList = struct {
+    run_ms: usize,
+    warmup_ms: usize,
+    program_args: [][]u8,
+};
+
+pub fn FnReturnType(comptime function: anytype) type {
+    return @typeInfo(@TypeOf(function)).Fn.return_type.?;
+}
+
+pub fn TimedResult(comptime T: type) type {
+    return struct {
+        elapsed_total: i128,
+        elapsed: i128,
+        value: T,
+    };
+}
+
+pub fn BenchmarkResult(comptime T: type) type {
+    return struct {
+        const Self = @This();
+
+        mean_ms: f64,
+        std_dev_ms: f64,
+        min_ms: f64,
+        max_ms: f64,
+        runs: usize,
+        results: std.ArrayList(TimedResult(T)),
+
+        pub fn lastResult(self: *const Self) T {
+            return self.results.getLast().value;
+        }
+
+        pub fn formatOutput(self: *const Self, allocator: Allocator, check_value: anytype) ![]u8 {
+            return std.fmt.allocPrint(
+                allocator,
+                "{d:.6},{d:.6},{d:.6},{d:.6},{d},{any}",
+                .{
+                    self.mean_ms,
+                    self.std_dev_ms,
+                    self.min_ms,
+                    self.max_ms,
+                    self.runs,
+                    check_value,
+                },
+            );
+        }
+
+        pub fn printOutput(self: *const Self, allocator: Allocator, check_value: anytype) !void {
+            const formatted_output = try self.formatOutput(allocator, check_value);
+
+            const stdout = std.io.getStdOut().writer();
+            try stdout.print("{s}\n", .{formatted_output});
+        }
+    };
+}
+
+pub fn createContext(comptime benchmark_fn: anytype) type {
+    // store the return type for the working function
+    const return_type = FnReturnType(benchmark_fn);
+
+    return struct {
+        const Self = @This();
+
+        /// run_ms:
+        ///   0: don't run
+        ///   1: check-output run
+        /// args:
+        ///   e.g.: .{ allocator, &arg1, arg2 }
+        pub fn run(allocator: Allocator, run_ms: usize, args: anytype) !?BenchmarkResult(return_type) {
+            const stderr = std.io.getStdErr().writer();
+
+            var benchmark_results = try std.ArrayList(TimedResult(return_type)).initCapacity(allocator, INITIAL_CAPACITY);
+
+            if (run_ms == 0) {
+                return null;
+            } else if (run_ms > 1) {
+                // start with a status dot, but not if this is a check-output run
+                try stderr.writeAll(".");
+            }
+
+            const run_ns: usize = run_ms * 1_000_000;
+
+            var elapsed_total: i128 = 0;
+            var last_time: i128 = nanoTimestamp();
+
+            while (elapsed_total < run_ns) {
+                const time_start = nanoTimestamp();
+
+                const current_value = @call(.auto, benchmark_fn, args);
+
+                const time_end = nanoTimestamp();
+
+                // print status dots every second if it isn't a check-output run
+                if (run_ms > 1 and time_end - last_time > 1_000_000_000) {
+                    last_time = time_end;
+                    try stderr.writeAll(".");
+                }
+
+                const elapsed = time_end - time_start;
+                elapsed_total += elapsed;
+
+                try benchmark_results.append(TimedResult(return_type){
+                    .elapsed_total = elapsed_total,
+                    .elapsed = elapsed,
+                    .value = current_value,
+                });
+            }
+
+            // add newline for non check-output runs
+            if (run_ms > 1) {
+                try stderr.writeAll("\n");
+            }
+
+            // calculate timings after completing the run
+            // (no unnecessary work during benchmark loop)
+            const min_ms = Self.calculateMin(&benchmark_results);
+            const max_ms = Self.calculateMax(&benchmark_results);
+            const mean_ms: f64 = Self.calculateMean(&benchmark_results);
+            const std_deviation: f64 = Self.calculateStdDeviation(&benchmark_results, mean_ms);
+
+            return BenchmarkResult(return_type){
+                .mean_ms = mean_ms,
+                .std_dev_ms = std_deviation,
+                .min_ms = min_ms,
+                .max_ms = max_ms,
+                .runs = benchmark_results.items.len,
+                .results = benchmark_results,
+            };
+        }
+
+        pub fn benchmark(allocator: Allocator, warmup_ms: usize, run_ms: usize, args: anytype) !?BenchmarkResult(return_type) {
+            // perform warmup runs
+            _ = try Self.run(allocator, warmup_ms, args);
+
+            // perform benchmark runs
+            return Self.run(allocator, run_ms, args);
+        }
+
+        fn calculateMin(results: *const std.ArrayList(TimedResult(return_type))) f64 {
+            var min_ms = std.math.floatMax(f64);
+
+            for (results.items) |result| {
+                const milliseconds: f64 = @as(f64, @floatFromInt(result.elapsed)) / 1_000_000.0;
+
+                if (milliseconds < min_ms) {
+                    min_ms = milliseconds;
+                }
+            }
+
+            return min_ms;
+        }
+
+        fn calculateMax(results: *const std.ArrayList(TimedResult(return_type))) f64 {
+            var max_ms = std.math.floatMin(f64);
+
+            for (results.items) |result| {
+                const milliseconds: f64 = @as(f64, @floatFromInt(result.elapsed)) / 1_000_000.0;
+
+                if (milliseconds > max_ms) {
+                    max_ms = milliseconds;
+                }
+            }
+
+            return max_ms;
+        }
+
+        fn calculateMean(results: *const std.ArrayList(TimedResult(return_type))) f64 {
+            var sum: f64 = 0.0;
+
+            for (results.*.items) |*result| {
+                sum += @as(f64, @floatFromInt(result.*.elapsed)) / 1_000_000.0;
+            }
+
+            return sum / @as(f64, @floatFromInt(results.*.items.len));
+        }
+
+        fn calculateStdDeviation(results: *const std.ArrayList(TimedResult(return_type)), mean_ms: f64) f64 {
+            var sum_squares: f64 = 0.0;
+
+            for (results.*.items) |*result| {
+                const diff: f64 = (@as(f64, @floatFromInt(result.*.elapsed)) / 1_000_000.0) - mean_ms;
+                sum_squares += diff * diff;
+            }
+
+            return std.math.sqrt(sum_squares / @as(f64, @floatFromInt(results.*.items.len)));
+        }
+    };
+}
+
+// Helper Functions
+
+pub fn loadArguments(allocator: Allocator) !ArgumentList {
+    const args_cli = try std.process.argsAlloc(allocator);
+
+    if (args_cli.len < 4) {
+        const stderr = std.io.getStdErr().writer();
+        try stderr.print("Usage: {s} <run_ms> <warmup_ms> ...<program args>\n", .{args_cli[0]});
+        std.process.exit(1);
+    }
+
+    const args = args_cli[1..];
+
+    const run_ms: usize = try std.fmt.parseInt(usize, args[0], 0);
+    const warmup_ms: usize = try std.fmt.parseInt(usize, args[1], 0);
+
+    return ArgumentList{
+        .run_ms = run_ms,
+        .warmup_ms = warmup_ms,
+        .program_args = args[2..],
+    };
+}
+
+pub fn fileReadLines(allocator: Allocator, file_path: []const u8) !std.ArrayList([]const u8) {
+    var file = try std.fs.cwd().openFile(file_path, .{ .mode = std.fs.File.OpenMode.read_only });
+    defer file.close();
+
+    const stat = try file.stat();
+    const file_buffer = try file.readToEndAlloc(allocator, stat.size);
+
+    var word_list = std.ArrayList([]const u8).init(allocator);
+
+    // Split by "\r?\n" and iterate through the resulting slices of "[]const u8"
+    var lines = std.mem.tokenizeAny(u8, file_buffer, "\r\n");
+
+    while (lines.next()) |line| {
+        try word_list.append(line);
+    }
+
+    return word_list;
+}

--- a/loops/zig/build.zig
+++ b/loops/zig/build.zig
@@ -1,0 +1,60 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    // Resolve target triplet of "cpu-os-abi" (native is default)
+    const target = b.standardTargetOptions(.{});
+
+    // Resolve optimization mode (debug is default)
+    const optimize = b.standardOptimizeOption(.{});
+
+    // Modules declaration
+    const benchmark = b.createModule(.{ .root_source_file = b.path("../../lib/zig/benchmark.zig") });
+    // const submod = b.createModule(.{ .root_source_file = b.path("src/submod/mod.zig") });
+
+    const exe = b.addExecutable(.{
+        .name = "run",
+        .root_source_file = b.path("run.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    exe.root_module.addImport("benchmark", benchmark);
+    // submod.addImport("benchmark", benchmark);
+
+    b.installArtifact(exe);
+
+    // This *creates* a Run step in the build graph, to be executed when another
+    // step is evaluated that depends on it. The next line below will establish
+    // such run a dependency.
+    const run_cmd = b.addRunArtifact(exe);
+    run_cmd.step.dependOn(b.getInstallStep());
+
+    // This allows the user to pass arguments to the application in the build
+    // command itself, like this: `zig build run -- arg1 arg2 etc`
+    if (b.args) |args| {
+        run_cmd.addArgs(args);
+    }
+
+    // This creates a build step. It will be visible in the `zig build --help` menu,
+    // and can be selected like this: `zig build run`
+    // This will evaluate the `run` step rather than the default, which is "install".
+    const run_step = b.step("run", "Run the application");
+    run_step.dependOn(&run_cmd.step);
+
+    const unit_tests = b.addTest(.{
+        .root_source_file = b.path("run.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    unit_tests.root_module.addImport("benchmark", benchmark);
+    // unit_tests.root_module.addImport("submod", submod);
+
+    const run_unit_tests = b.addRunArtifact(unit_tests);
+
+    // Similar to creating the run step earlier, this exposes a `test` step to
+    // the `zig build --help` menu, providing a way for the user to request
+    // running the unit tests.
+    const test_step = b.step("test", "Run unit tests");
+    test_step.dependOn(&run_unit_tests.step);
+}

--- a/loops/zig/loop.zig
+++ b/loops/zig/loop.zig
@@ -1,0 +1,26 @@
+const std = @import("std");
+
+const rand = std.crypto.random;
+
+pub fn loops(comptime iterations_outer: u32, comptime iterations_inner: u32, divisor: u32) u32 {
+    // get a random number 0 <= r < 10k
+    const random = rand.intRangeLessThanBiased(u32, 0, 10_000);
+
+    // array of 10k elements initialized to 0
+    var arr = [_]u32{0} ** iterations_outer;
+
+    // 10k outer loop iterations
+    // iterate over array itself to prevent permanent bound checks for arr[i]
+    for (&arr) |*elem| {
+        // 10k inner loop iterations, per outer loop iteration
+        for (0..iterations_inner) |j| {
+            // simple sum
+            elem.* += @as(u32, @truncate(j)) % divisor;
+        }
+
+        // add a random value to each element in array
+        elem.* += random;
+    }
+
+    return arr[random];
+}

--- a/loops/zig/run.zig
+++ b/loops/zig/run.zig
@@ -1,0 +1,28 @@
+const std = @import("std");
+
+const benchmark = @import("benchmark");
+const loops = @import("./loop.zig").loops;
+
+const ITERATIONS: u32 = 10_000;
+
+pub fn main() !void {
+    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    // retrieve arguments for benchmark, contains program arguments
+    const args = try benchmark.loadArguments(allocator);
+
+    // parse program arguments
+    const divisor: u32 = try std.fmt.parseInt(u32, args.program_args[0], 0);
+
+    // perform full benchmark
+    const context = benchmark.createContext(loops);
+    const stats = (try context.benchmark(allocator, args.warmup_ms, args.run_ms, .{ ITERATIONS, ITERATIONS, divisor })).?;
+
+    // get last result for success checks
+    const last_result = stats.lastResult();
+
+    // output results
+    try stats.printOutput(allocator, last_result);
+}

--- a/run.sh
+++ b/run.sh
@@ -158,6 +158,7 @@ run "C++" "./cpp/run" "./cpp/run"
 run "Fortran" "./fortran/run" "./fortran/run"
 run "Java" "./jvm/run.class" "java -cp .:../lib/java jvm.run"
 run "Java Native" "./java-native-image/run" "./java-native-image/run"
+run "Zig" "./zig/zig-out/bin/run" "./zig/zig-out/bin/run"
 ####### END The languages
 
 echo


### PR DESCRIPTION
Closes #384

- reusable common code
- implements all Zig benchmarks
  - [x] Benchmark Utility
  - [x] hello-world
  - [x] loops
  - [x] fibonacci
  - [x] levenshtein

---

use `std.process.argsAlloc` for cross-platform support
- [std.process.argsWithAllocator](https://github.com/ziglang/zig/blob/b5a2487/lib/std/process.zig#L1194-L1197) returns only an iterator
- [std.process.args](https://github.com/ziglang/zig/blob/b5a2487/lib/std/process.zig#L1188-L1192) is not cross-platform compatible
- [std.os.argv](https://github.com/ziglang/zig/blob/b5a2487/lib/std/os.zig#L49-L56) is not cross-platform compatible

<!-- Thanks for helping to improve this project! 🙏 -->

I have:

* [x] Read the project [README](../../blob/main/README.md), including the [benchmark descriptions](../../blob/main/README.md#available-benchmarks)
* [x] Read the PR template instructions before I deleted them
* [x] Understood that if I have changed something that could impact performance of one or more contributions, I should provide results benchmark runs, using the `run.sh` script, from before and after the change.

## Description of changes

<!-- 

Please include a descrition for your change. Things like:

* Why it is done (a problem description)
  If there's an issue describing the problem, please refer it. If your PR is fixing the problem described in the issue, use the _Fixes #<issue-no>_  syntax.
* Why it is done the way you have done it (a solution description)

Please help us understand the changes and the rationale even if we are not experts or even familiar with the particular language you are providing changes for.

If you provide changes to the implementation of one or more language, for one or more benchmark, please include output from benchmark runs, using run.sh, from before and after the change. (TIPS: You can use a copy of run.sh to avoid running the benchmarks for other languages.) Please provide the results as text rather than as screen dumps.

Thanks again for contributing!
-->

Add Zig in-process benchmark utility and the corresponding files to measure runtimes.