### PR TITLE
Status dots fix

### DIFF
--- a/lib/c/benchmark.c
+++ b/lib/c/benchmark.c
@@ -67,7 +67,7 @@ benchmark_stats_t benchmark_run(benchmark_fn fn, void* data, int run_ms) {
     last_result = fn(data);
     int64_t t1 = get_time_ns();
     // Don't print status dots if it is a check-output run
-    if (run_ms > 1 && t1 - last_status_t > 1000000000) {
+    if (run_ms > 1 && t0 - last_status_t > 1000000000) {
       last_status_t = t1;
       fprintf(stderr, ".");
       fflush(stderr);

--- a/lib/clojure/src/languages/benchmark.clj
+++ b/lib/clojure/src/languages/benchmark.clj
@@ -43,7 +43,7 @@
                          total-elapsed-time (+ last-tet elapsed-time)
                          timed-result [total-elapsed-time elapsed-time result]
                          print-status? (and (> run-ms 1) ; Not if check-output run
-                                            (> (- t1 last-status-t) 1000000000))]
+                                            (> (- t0 last-status-t) 1000000000))]
                      (when print-status? (print ".") (flush))
                      (if (< total-elapsed-time run-ns)
                        (recur (conj results timed-result) total-elapsed-time (if print-status?

--- a/lib/fortran/benchmark.f90
+++ b/lib/fortran/benchmark.f90
@@ -48,6 +48,7 @@ contains
     max_time = 0.0
     print_status = (run_ms > 1)
     call system_clock(count_rate=count_rate)  ! Get the count rate
+    last_status_t = 0
 
     if (print_status) then
       write(0, '(A)', advance='no') "."
@@ -55,6 +56,11 @@ contains
     end if
 
     do while (total_elapsed_time < run_ms * 1.0e6)
+      if (print_status .and. (total_elapsed_time - last_status_t) > 1.0e9) then
+        last_status_t = total_elapsed_time
+        write(0, '(A)', advance='no') "."
+        flush(0)
+      end if
       call system_clock(start_time, count_rate=count_rate)  ! Use nanosecond precision
       result%result = func_ptr()
       call system_clock(end_time, count_rate=count_rate)    ! Use nanosecond precision
@@ -70,11 +76,6 @@ contains
       count = count + 1
       if (elapsed_times(count) < min_time) min_time = elapsed_times(count)
       if (elapsed_times(count) > max_time) max_time = elapsed_times(count)
-      if (print_status .and. (end_time - last_status_t) > count_rate) then
-        last_status_t = end_time
-        write(0, '(A)', advance='no') "."
-        flush(0)
-      end if
     end do
 
     if (print_status) then

--- a/lib/java/languages/Benchmark.java
+++ b/lib/java/languages/Benchmark.java
@@ -80,13 +80,13 @@ public class Benchmark {
       long t0 = System.nanoTime();
       T result = f.get();
       long t1 = System.nanoTime();
+      long elapsedTime = t1 - t0;
       // Only print status dot if not check-output run
-      if (runMs > 1 && t1 - lastStatusT > 1_000_000_000) {
+      if (runMs > 1 && t0 - lastStatusT > 1_000_000_000) {
         lastStatusT = t1;
         System.err.print(".");
         System.err.flush();
       }
-      long elapsedTime = t1 - t0;
       totalElapsedTime += elapsedTime;
       results.add(new TimedResult<>(totalElapsedTime, elapsedTime, result));
     }

--- a/lib/zig/benchmark.zig
+++ b/lib/zig/benchmark.zig
@@ -98,7 +98,7 @@ pub fn createContext(comptime benchmark_fn: anytype) type {
                 const time_end = nanoTimestamp();
 
                 // print status dots every second if it isn't a check-output run
-                if (run_ms > 1 and time_end - last_time > 1_000_000_000) {
+                if (run_ms > 1 and time_start - last_time > 1_000_000_000) {
                     last_time = time_end;
                     try stderr.writeAll(".");
                 }


### PR DESCRIPTION
<!-- Thanks for helping to improve this project! 🙏 -->

I have:

* [x] Read the project [README](../../blob/main/README.md), including the [benchmark descriptions](../../blob/main/README.md#available-benchmarks)
* [x] Read the PR template instructions before I deleted them
* [x] Understood that if I have changed something that could impact performance of one or more contributions, I should provide results benchmark runs, using the `run.sh` script, from before and after the change.

## Description of changes

Fixed the status dot printing to consistently print 1 dot per second (at the beginning of the second).

For Fortran it was more of fixing so that the dots printed at all. Nothing needed for C++, which seemed to behave already.

Fixes #388

