### PR TITLE
Detect CPU model name regardless of system language

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -51,7 +51,7 @@ arch=$(uname -m)
 if [[ "${os}" == "darwin"* || "${os}" == "freebsd"* ]]; then
     model=$(sysctl -n machdep.cpu.brand_string)
 elif [[ "${os}" == "linux-gnu"* ]]; then
-    model=$(lscpu | grep "Model name" | awk -F: '{print $2}' | sed -e 's/^[[:space:]]*//')
+    model=$(lscpu --extended=MODELNAME | awk -F: 'NR==2 {print $1; exit}')
 else
     model="Unknown"
 fi


### PR DESCRIPTION
Drops dependency for `sed` command in `run.sh` as side-effect.

__Alternative Commands:__
- `model=$(lscpu --extended=MODELNAME | head -n 2 | tail -n 1)`
- `model=$(lscpu --extended=MODELNAME | sed -n '2p')`

<!-- Thanks for helping to improve this project! 🙏 -->

I have:

* [x] Read the project [README](../../blob/main/README.md), including the [benchmark descriptions](../../blob/main/README.md#available-benchmarks)
* [x] Read the PR template instructions before I deleted them
* [x] Understood that if I have changed something that could impact performance of one or more contributions, I should provide results benchmark runs, using the `run.sh` script, from before and after the change.

## Description of changes

The old command results in empty output if the system is not set up for English.

![Old Command](https://github.com/user-attachments/assets/bbb00d6f-47cc-49ba-a662-2809676c34be)

<details>
<summary>Output for a German System</summary>

```SH
$> lscpu
Architektur:                       x86_64
  CPU Operationsmodus:             32-bit, 64-bit
  Adressgrößen:                    48 bits physical, 48 bits virtual
  Byte-Reihenfolge:                Little Endian
CPU(s):                            32
  Liste der Online-CPU(s):         0-31
Anbieterkennung:                   AuthenticAMD
  Modellname:                      AMD Ryzen 9 5950X 16-Core Processor
    Prozessorfamilie:              25
    Modell:                        33
    Thread(s) pro Kern:            2
    Kern(e) pro Sockel:            16
    Sockel:                        1
    Stepping:                      0
    Übertaktung:                   aktiviert
    Skalierung der CPU(s):         59%
    Maximale Taktfrequenz der CPU: 5084,0000
    Minimale Taktfrequenz der CPU: 550,0000
    BogoMIPS:                      6787,23
    Markierungen:                  fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm constant_tsc rep_good nopl xtopology nonstop_tsc cpuid extd_apicid aperfmperf rapl pni pclmulqdq monitor
                                    ssse3 fma cx16 sse4_1 sse4_2 x2apic movbe popcnt aes xsave avx f16c rdrand lahf_lm cmp_legacy svm extapic cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw ibs skinit wdt tce topoext perfctr_core perfctr_nb bpext perfctr_llc mwaitx cpb cat_l3 cdp_
                                   l3 hw_pstate ssbd mba ibrs ibpb stibp vmmcall fsgsbase bmi1 avx2 smep bmi2 erms invpcid cqm rdt_a rdseed adx smap clflushopt clwb sha_ni xsaveopt xsavec xgetbv1 xsaves cqm_llc cqm_occup_llc cqm_mbm_total cqm_mbm_local user_shstk clzero irperf xsaveer
                                   ptr rdpru wbnoinvd arat npt lbrv svm_lock nrip_save tsc_scale vmcb_clean flushbyasid decodeassists pausefilter pfthreshold avic v_vmsave_vmload vgif v_spec_ctrl umip pku ospke vaes vpclmulqdq rdpid overflow_recov succor smca fsrm debug_swap
Virtualisierungsfunktionen:
  Virtualisierung:                 AMD-V
Caches (Gesamtsumme):
  L1d:                             512 KiB (16 Instanzen)
  L1i:                             512 KiB (16 Instanzen)
  L2:                              8 MiB (16 Instanzen)
  L3:                              64 MiB (2 Instanzen)
NUMA:
  NUMA-Knoten:                     1
  NUMA-Knoten0 CPU(s):             0-31
Schwachstellen:
  Gather data sampling:            Not affected
  Itlb multihit:                   Not affected
  L1tf:                            Not affected
  Mds:                             Not affected
  Meltdown:                        Not affected
  Mmio stale data:                 Not affected
  Reg file data sampling:          Not affected
  Retbleed:                        Not affected
  Spec rstack overflow:            Mitigation; Safe RET
  Spec store bypass:               Mitigation; Speculative Store Bypass disabled via prctl
  Spectre v1:                      Mitigation; usercopy/swapgs barriers and __user pointer sanitization
  Spectre v2:                      Mitigation; Retpolines; IBPB conditional; IBRS_FW; STIBP always-on; RSB filling; PBRSB-eIBRS Not affected; BHI Not affected
  Srbds:                           Not affected
  Tsx async abort:                 Not affected
```
</details>

This results in an empty entry between the GitHub handle and RAM size.

```SH
$> export BLANGS='Rust,Zig' && ../compile.sh -l $BLANGS && ../run.sh  -u zierf -l $BLANGS -w 500 -t 1000
Starting compiles for loops

Compiling Zig

Done with compiles for loops
Running loops benchmark...
Results will be written to: /tmp/languages-benchmark/loops_zierf_1000_e6fb562_only_langs.csv

Checking loops Zig
Check passed
Benchmarking loops Zig
./zig/zig-out/bin/run 1000 500 40
.
.
loops,2025-02-01T20:45:11Z,e6fb562,true,zierf,,62GB,linux-gnu,x86_64,Zig,1000,125.802938,1.815676,123.991356,128.190594,8
```

The new command no longer requires `sed` and limits the output for `lscpu` to a machine-readable format with only the model name. The first CPU model name is then filtered out with `awk`, since an extra output line was previously generated for each core.

![New Command](https://github.com/user-attachments/assets/badc9d61-0080-4ee6-955b-1e9825099c77)

<details>
<summary>Output for MODELNAME</summary>

```SH
$> lscpu --extended=MODELNAME
MODELNAME
AMD Ryzen 9 5950X 16-Core Processor
AMD Ryzen 9 5950X 16-Core Processor
AMD Ryzen 9 5950X 16-Core Processor
AMD Ryzen 9 5950X 16-Core Processor
AMD Ryzen 9 5950X 16-Core Processor
AMD Ryzen 9 5950X 16-Core Processor
AMD Ryzen 9 5950X 16-Core Processor
AMD Ryzen 9 5950X 16-Core Processor
AMD Ryzen 9 5950X 16-Core Processor
AMD Ryzen 9 5950X 16-Core Processor
AMD Ryzen 9 5950X 16-Core Processor
AMD Ryzen 9 5950X 16-Core Processor
AMD Ryzen 9 5950X 16-Core Processor
AMD Ryzen 9 5950X 16-Core Processor
AMD Ryzen 9 5950X 16-Core Processor
AMD Ryzen 9 5950X 16-Core Processor
AMD Ryzen 9 5950X 16-Core Processor
AMD Ryzen 9 5950X 16-Core Processor
AMD Ryzen 9 5950X 16-Core Processor
AMD Ryzen 9 5950X 16-Core Processor
AMD Ryzen 9 5950X 16-Core Processor
AMD Ryzen 9 5950X 16-Core Processor
AMD Ryzen 9 5950X 16-Core Processor
AMD Ryzen 9 5950X 16-Core Processor
AMD Ryzen 9 5950X 16-Core Processor
AMD Ryzen 9 5950X 16-Core Processor
AMD Ryzen 9 5950X 16-Core Processor
AMD Ryzen 9 5950X 16-Core Processor
AMD Ryzen 9 5950X 16-Core Processor
AMD Ryzen 9 5950X 16-Core Processor
AMD Ryzen 9 5950X 16-Core Processor
AMD Ryzen 9 5950X 16-Core Processor
```
</details>

As before, the first CPU available is used. May require further testing when running benchmarks on systems with multiple CPUs.