### PR TITLE
In-process runner: Crystal: Use nanoseconds for the measurements

### DIFF
--- a/lib/crystal/benchmark.cr
+++ b/lib/crystal/benchmark.cr
@@ -1,7 +1,7 @@
 module Enumerable
     def variance
       mean = self.sum / self.size
-      sum = self.reduce(0.0) { |acc, cur| acc + (cur-mean) ** 2 }
+      sum = self.reduce(0) { |acc, cur| acc + (cur-mean) ** 2 }
       sum/(self.size - 1).to_f
     end
 
@@ -11,14 +11,14 @@ module Enumerable
 end
 
 def bench(run_ms : Int32, &fn)
-	times = Array(Float64).new
+	times = Array(Int64).new
 	result = 0
 	secs = 0
 	run_ns = run_ms * 1_000_000.0
 
 	while(times.sum < run_ns && !(times.sum == 0 && times.size > 0))
 		a = Time.measure {result = yield}
-		times << a.nanoseconds.to_f
+		times << a.nanoseconds
 
 		if (times.sum / 1_000_000_000).round > secs
 			STDERR.print '.'
@@ -34,7 +34,7 @@ def format_bench(data, &formatter)
 	raise "no data!" if data[:times].empty?
 
 	result = yield data[:result]
-	times = data[:times].map { |t| t / 1_000_000 } # Convert nanoseconds to milliseconds
+	times = data[:times].map &./(1_000_000)
 
 	# mean_ms,std-dev-ms,min_ms,max_ms,times,result
 	"#{times.sum/times.size},#{times.std_dev},#{times.min},#{times.max},#{times.size},#{result}"

--- a/lib/crystal/benchmark.cr
+++ b/lib/crystal/benchmark.cr
@@ -1,7 +1,7 @@
 module Enumerable
     def variance
       mean = self.sum / self.size
-      sum = self.reduce(0) { |acc, cur| acc + (cur-mean) ** 2 }
+      sum = self.reduce(0.0) { |acc, cur| acc + (cur-mean) ** 2 }
       sum/(self.size - 1).to_f
     end
 
@@ -11,15 +11,16 @@ module Enumerable
 end
 
 def bench(run_ms : Int32, &fn)
-	times = Array(Int32).new
+	times = Array(Float64).new
 	result = 0
 	secs = 0
-	
-	while(times.sum < run_ms && !(times.sum == 0 && times.size > 0))
-		a = Time.measure {result = yield}
-		times << a.milliseconds
+	run_ns = run_ms * 1_000_000.0
 
-		if (times.sum / 1000).round > secs
+	while(times.sum < run_ns && !(times.sum == 0 && times.size > 0))
+		a = Time.measure {result = yield}
+		times << a.nanoseconds.to_f
+
+		if (times.sum / 1_000_000_000).round > secs
 			STDERR.print '.'
 			secs += 1
 		end
@@ -33,8 +34,8 @@ def format_bench(data, &formatter)
 	raise "no data!" if data[:times].empty?
 
 	result = yield data[:result]
-	times = data[:times]
+	times = data[:times].map { |t| t / 1_000_000 } # Convert nanoseconds to milliseconds
 
 	# mean_ms,std-dev-ms,min_ms,max_ms,times,result
-	return "#{times.sum/times.size},#{times.std_dev},#{times.min},#{times.max},#{times.size},#{result}"
+	"#{times.sum/times.size},#{times.std_dev},#{times.min},#{times.max},#{times.size},#{result}"
 end


### PR DESCRIPTION
I have:

* [x] Read the project [README](../../blob/main/README.md), including the [benchmark descriptions](../../blob/main/README.md#available-benchmarks)
* [x] Read the PR template instructions before I deleted them
* [x] Understood that if I have changed something that could impact performance of one or more contributions, I should provide results benchmark runs, using the `run.sh` script, from before and after the change.

## Description of changes

The Crystal benchmark utility was measuring elapsed time in milliseconds. Now fixed so that it uses nanoseconds, like the other benchmark utility implementations do. Making it ready for when Crystal nails some benchmark in sub milliseconds, and also generally more accurate.

Sample benchmark run:

**Before**:

```
❯ ../run.sh -l Crystal    
Results will be written to: /tmp/languages-benchmark/2025-02-03T08-47-23Z_JDoe_10000_c8a7d4c_Crystal.csv

Running levenshtein benchmark...

Checking levenshtein Crystal
./crystal/run 1 0 levenshtein-words.txt


Check passed
Benchmarking levenshtein Crystal
./crystal/run 10000 2000 levenshtein-words.txt
..
..........
levenshtein,2025-02-03T08:47:23Z,c8a7d4c,true,JDoe,Apple M4 Max,64GB,darwin24,arm64,Crystal,10000,42.68936170212766,1.5856237202715189,42,64,235

Done running levenshtein benchmark
Results were written to: /tmp/languages-benchmark/2025-02-03T08-47-23Z_JDoe_10000_c8a7d4c_Crystal.csv
```

**After**:

```
❯ ../run.sh -l Crystal    
Results will be written to: /tmp/languages-benchmark/2025-02-03T07-55-30Z_JDoe_10000_c8a7d4c_Crystal.csv

Running levenshtein benchmark...

Checking levenshtein Crystal
./crystal/run 1 0 levenshtein-words.txt


Check passed
Benchmarking levenshtein Crystal
./crystal/run 10000 2000 levenshtein-words.txt
..
..........
levenshtein,2025-02-03T07:55:30Z,c8a7d4c,true,JDoe,Apple M4 Max,64GB,darwin24,arm64,Crystal,10000,43.19697160775864,0.570575409818885,42.246583,45.121875,232

Done running levenshtein benchmark
Results were written to: /tmp/languages-benchmark/2025-02-03T07-55-30Z_JDoe_10000_c8a7d4c_Crystal.csv
```

(Note the min, and max times are now reported with decimals, not integers.)

Can you have a look, @Tamnac? I'm not sure I can trust my Crystal assistant (yes, CoPilot).
