### PR TITLE
Racket in process

### DIFF
--- a/fibonacci/racket/fibonacci.rkt
+++ b/fibonacci/racket/fibonacci.rkt
@@ -1,0 +1,18 @@
+#lang racket/base
+
+(require racket/require
+         (for-syntax racket/base) ;; filtered-in fails without this
+         (filtered-in
+          (λ (name)
+            (and (regexp-match #rx"^unsafe-fx" name)
+                 (regexp-replace #rx"unsafe-" name "")))
+          racket/unsafe/ops))
+
+(provide fibonacci)
+
+(define (fibonacci a)
+  (case a
+    [(0 1) a]
+    [else
+     (fx+ (fibonacci (fx- a 1))
+          (fibonacci (fx- a 2)))]))

--- a/fibonacci/racket/run.rkt
+++ b/fibonacci/racket/run.rkt
@@ -1,0 +1,17 @@
+#lang racket
+(require (file "../../lib/racket/benchmark.rkt")
+         "fibonacci.rkt"
+         racket/cmdline
+         racket/file)
+
+(command-line
+  #:args args
+  (define run-ms (string->number (list-ref args 0)))
+  (define warmup-ms (string->number (list-ref args 1)))
+  (define n (string->number (list-ref args 2)))
+
+  ;; Run a warmup (no status output if warmup-ms = 1)
+  (run (λ () (fibonacci n)) warmup-ms)
+  ;; Run the benchmark and format the results.
+  (define results (run (λ () (fibonacci n)) run-ms))
+  (printf "~a\n" (format-results results)))

--- a/hello-world/racket/run.rkt
+++ b/hello-world/racket/run.rkt
@@ -1,0 +1,2 @@
+#lang racket/base
+(displayln "Hello, World!")

--- a/languages.sh
+++ b/languages.sh
@@ -13,6 +13,7 @@ function compile_languages {
   compile 'Java' 'jvm' 'javac -cp ../lib/java jvm/*.java'
   compile 'Java Native' 'java-native-image' '(cd java-native-image ; native-image -cp ..:../../lib/java --no-fallback -O3 --pgo-instrument -march=native jvm.run) && ./java-native-image/jvm.run -XX:ProfilesDumpFile=java-native-image/run.iprof 10000 2000 $(./check-output.sh -i) && (cd java-native-image ; native-image -cp ..:../../lib/java -O3 --pgo=run.iprof -march=native jvm.run -o run)'
   compile 'Fortran' 'fortran' 'gfortran -O3 -J../lib/fortran ../lib/fortran/benchmark.f90 fortran/*.f90 -o fortran/run'
+  compile 'Racket' 'racket' '(cd racket && raco make run.rkt && raco demod -o run.zo run.rkt && raco exe -o run run.zo)'
   compile 'Rust' 'rust' 'cargo build --manifest-path rust/Cargo.toml --release'
   compile 'Zig' 'zig' 'zig build --build-file zig/build.zig --prefix ${PWD}/zig/zig-out --cache-dir ${PWD}/zig/.zig-cache --release=fast'
 }
@@ -30,6 +31,7 @@ function run_languages {
   run 'Java Native' './java-native-image/run' './java-native-image/run'
   run "Python" "./py/run.py" "python3.12 ./py/run.py"
   run "Python JIT" "./py-jit/run.py" "python3.12 ./py-jit/run.py"
+  run "Racket" './racket/run' './racket/run'
   run 'Ruby' 'ruby/run.rb' 'ruby ruby/run.rb'
   run "Ruby YJIT" "./ruby/code.rb" "ruby --yjit ./ruby/run.rb"
   run "Rust" "./rust/target/release/run" "./rust/target/release/run"

--- a/levenshtein/racket/benchmark.rkt
+++ b/levenshtein/racket/benchmark.rkt
@@ -1,0 +1,90 @@
+#lang racket
+(require racket/hash)
+
+(provide run format-results)
+
+;; A helper to get a (rough) nanosecond reading.
+;; (Note: Racket doesn’t have a built-in monotonic nanoTime,
+;; so we use current-inexact-milliseconds multiplied up.)
+(define (current-nanotime)
+  (inexact->exact (round (* (current-inexact-milliseconds) 1000000))))
+
+;; run : (-> any) number -> hash
+;;
+;; f is the function to run repeatedly.
+;; run-ms is the total run time in milliseconds.
+;;
+;; Special cases:
+;;   * run-ms = 0 => don’t run, just return a “dummy” result.
+;;   * run-ms = 1 => don’t print status dots (assumed to be a correctness check).
+;;
+;; Returns a hash with keys:
+;;   'runs, 'result, 'mean-ms, 'min-ms, 'max-ms, 'std-dev-ms
+(define (run f run-ms)
+  (if (= run-ms 0)
+      (hash 'runs 0
+            'result (f)
+            'mean-ms 0
+            'min-ms 0
+            'max-ms 0
+            'std-dev-ms 0)
+      (let* ([run-ns (* run-ms 1000000)] ; convert run-ms (milliseconds) to nanoseconds
+             [init-t (current-nanotime)]
+             [last-status-t init-t])
+        (when (> run-ms 1)
+          (display ".") (flush-output))
+        (define (loop last-tet results last-status-t)
+          (let* ([t0 (current-nanotime)]
+                 [result (f)]
+                 [t1 (current-nanotime)]
+                 [elapsed-time (- t1 t0)]
+                 [total-elapsed-time (+ last-tet elapsed-time)]
+                 [timed-result (list total-elapsed-time elapsed-time result)]
+                 [print-status? (and (> run-ms 1)
+                                     (> (- t0 last-status-t) 1000000000))])
+            (when print-status?
+              (display ".") (flush-output))
+            (if (< total-elapsed-time run-ns)
+                (loop total-elapsed-time
+                      (cons timed-result results)
+                      (if print-status? t1 last-status-t))
+                (reverse (cons timed-result results)))))
+        (let* ([final-results (loop 0 '() last-status-t)]
+               ;; Get the final timed result (i.e. from the last run)
+               [last-run (car (reverse final-results))]
+               [total-elapsed-time (first last-run)]
+               [result (list-ref last-run 2)]
+               [elapsed-times (map second final-results)]
+               [runs (length final-results)]
+               [mean-ns (/ total-elapsed-time runs)]
+               [min-ns (apply min elapsed-times)]
+               [max-ns (apply max elapsed-times)]
+               [variance (/ (apply + (map (λ (t)
+                                            (expt (- t mean-ns) 2))
+                                          elapsed-times))
+                            runs)]
+               [std-dev-ns (sqrt variance)]
+               [mean-ms (/ mean-ns 1000000.0)]
+               [min-ms (/ min-ns 1000000.0)]
+               [max-ms (/ max-ns 1000000.0)]
+               [std-dev-ms (/ std-dev-ns 1000000.0)])
+          (when (> run-ms 1)
+            (newline))
+          (hash 'runs runs
+                'result result
+                'mean-ms mean-ms
+                'min-ms min-ms
+                'max-ms max-ms
+                'std-dev-ms std-dev-ms)))))
+
+;; format-results : hash -> string
+;; Formats the benchmark results as:
+;;   mean-ms,std-dev-ms,min-ms,max-ms,runs,result
+(define (format-results stats)
+  (format "~a,~a,~a,~a,~a,~a"
+          (hash-ref stats 'mean-ms)
+          (hash-ref stats 'std-dev-ms)
+          (hash-ref stats 'min-ms)
+          (hash-ref stats 'max-ms)
+          (hash-ref stats 'runs)
+          (hash-ref stats 'result)))

--- a/levenshtein/racket/run.rkt
+++ b/levenshtein/racket/run.rkt
@@ -1,28 +1,18 @@
 #lang racket
-
-(require racket/require
+(require "benchmark.rkt"
          "levenshtein.rkt"
-         (for-syntax racket/base) ;; filtered-in fails without this
-         (only-in racket/fixnum
-                  make-fxvector
-                  for/fxvector)
-         (filtered-in
-          (λ (name)
-            (and (regexp-match #rx"^unsafe-fx" name)
-                 (regexp-replace #rx"unsafe-" name "")))
-          racket/unsafe/ops)
          racket/cmdline
-         racket/list
-         racket/match
          racket/file)
 
 (command-line
   #:args args
-
   (define run-ms (string->number (list-ref args 0)))
   (define warmup-ms (string->number (list-ref args 1)))
   (define words (file->lines (list-ref args 2)))
 
-  (define distances (levenshtein-distances words))
-  (define total-distance (apply + distances))
-  (printf "Total Levenshtein distance: ~a\n" total-distance))
+  ;; Run a warmup (no status output if warmup-ms = 1)
+  (run (λ () (levenshtein-distances words)) warmup-ms)
+  ;; Run the benchmark and format the results.
+  (define results (run (λ () (levenshtein-distances words)) run-ms))
+  (define total-distance (apply + (hash-ref results 'result)))
+  (printf "~a\n" (format-results (hash-set results 'result total-distance))))

--- a/levenshtein/racket/run.rkt
+++ b/levenshtein/racket/run.rkt
@@ -1,0 +1,28 @@
+#lang racket
+
+(require racket/require
+         "levenshtein.rkt"
+         (for-syntax racket/base) ;; filtered-in fails without this
+         (only-in racket/fixnum
+                  make-fxvector
+                  for/fxvector)
+         (filtered-in
+          (λ (name)
+            (and (regexp-match #rx"^unsafe-fx" name)
+                 (regexp-replace #rx"unsafe-" name "")))
+          racket/unsafe/ops)
+         racket/cmdline
+         racket/list
+         racket/match
+         racket/file)
+
+(command-line
+  #:args args
+
+  (define run-ms (string->number (list-ref args 0)))
+  (define warmup-ms (string->number (list-ref args 1)))
+  (define words (file->lines (list-ref args 2)))
+
+  (define distances (levenshtein-distances words))
+  (define total-distance (apply + distances))
+  (printf "Total Levenshtein distance: ~a\n" total-distance))

--- a/levenshtein/racket/run.rkt
+++ b/levenshtein/racket/run.rkt
@@ -1,5 +1,5 @@
 #lang racket
-(require "benchmark.rkt"
+(require (file "../../lib/racket/benchmark.rkt")
          "levenshtein.rkt"
          racket/cmdline
          racket/file)

--- a/lib/racket/benchmark.rkt
+++ b/lib/racket/benchmark.rkt
@@ -6,6 +6,8 @@
 ;; A helper to get a (rough) nanosecond reading.
 ;; (Note: Racket doesn’t have a built-in monotonic nanoTime,
 ;; so we use current-inexact-milliseconds multiplied up.)
+;; We get away with it until there is a benchmark that Racket
+;; completes in sub-milliseconds time.
 (define (current-nanotime)
   (inexact->exact (round (* (current-inexact-milliseconds) 1000000))))
 

--- a/lib/racket/benchmark.rkt
+++ b/lib/racket/benchmark.rkt
@@ -34,7 +34,8 @@
              [init-t (current-nanotime)]
              [last-status-t init-t])
         (when (> run-ms 1)
-          (display ".") (flush-output))
+          (display "." (current-error-port))
+          (flush-output (current-error-port)))
         (define (loop last-tet results last-status-t)
           (let* ([t0 (current-nanotime)]
                  [result (f)]
@@ -45,7 +46,8 @@
                  [print-status? (and (> run-ms 1)
                                      (> (- t0 last-status-t) 1000000000))])
             (when print-status?
-              (display ".") (flush-output))
+              (display "." (current-error-port))
+              (flush-output (current-error-port)))
             (if (< total-elapsed-time run-ns)
                 (loop total-elapsed-time
                       (cons timed-result results)
@@ -71,7 +73,7 @@
                [max-ms (/ max-ns 1000000.0)]
                [std-dev-ms (/ std-dev-ns 1000000.0)])
           (when (> run-ms 1)
-            (newline))
+            (newline (current-error-port)))
           (hash 'runs runs
                 'result result
                 'mean-ms mean-ms

--- a/loops/racket/loops.rkt
+++ b/loops/racket/loops.rkt
@@ -1,0 +1,37 @@
+#lang racket/base
+
+(require racket/require
+         (for-syntax racket/base) ;; filtered-in fails without this
+         (only-in racket/fixnum
+                  make-fxvector)
+         (filtered-in
+          (λ (name)
+            (and (regexp-match #rx"^unsafe-fx" name)
+                 (regexp-replace #rx"unsafe-" name "")))
+          racket/unsafe/ops))
+
+(provide loops)
+
+(define length #e1e4)
+
+(define (loops u)
+  (define r (random (add1 length) (make-pseudo-random-generator)))
+  ;; Racket's numeric tower makes doing exactly-32-bit integer computations
+  ;; tricky. Since the results of the computation don't matter too much, let's use
+  ;; fixnums, which are larger on 64-bit platforms but 1 or 2 bits shy on 32-bit
+  ;; platforms. Given the same r and u, this should produce the same result as the
+  ;; C program on a 64-bit platform (where it will unfortunately waste space).
+  ;;
+  ;; TODO: use make-s32vector, but what kinds of arithmetic operators for C
+  ;; semantics?
+  (define a (make-fxvector length))
+
+  ;; no /wraparound variants: if the reference C program exhibits any signed
+  ;; integer overflow, it's in UB territory. Assume it doesn't.
+  ;; https://stackoverflow.com/a/19843181
+  (for ([i (in-range 0 length)])
+    (for ([j (in-range 0 length)])
+      (fxvector-set! a i (fx+ (fxvector-ref a i) (fxremainder j u))))
+    (fxvector-set! a i (fx+ (fxvector-ref a i) r)))
+
+  (fxvector-ref a r))

--- a/loops/racket/run.rkt
+++ b/loops/racket/run.rkt
@@ -1,0 +1,17 @@
+#lang racket
+(require (file "../../lib/racket/benchmark.rkt")
+         "loops.rkt"
+         racket/cmdline
+         racket/file)
+
+(command-line
+  #:args args
+  (define run-ms (string->number (list-ref args 0)))
+  (define warmup-ms (string->number (list-ref args 1)))
+  (define u (string->number (list-ref args 2)))
+
+  ;; Run a warmup (no status output if warmup-ms = 1)
+  (run (λ () (loops u)) warmup-ms)
+  ;; Run the benchmark and format the results.
+  (define results (run (λ () (loops u)) run-ms))
+  (printf "~a\n" (format-results results)))


### PR DESCRIPTION
<!-- Thanks for helping to improve this project! 🙏 -->

I have:

* [x] Read the project [README](../../blob/main/README.md), including the [benchmark descriptions](../../blob/main/README.md#available-benchmarks)
* [x] Read the PR template instructions before I deleted them
* [x] Understood that if I have changed something that could impact performance of one or more contributions, I should provide results benchmark runs, using the `run.sh` script, from before and after the change.

## Description of changes

Ported the Racket contributions to the in-process runner.

According to ChatGPT there is no built-in nanoseconds monotonic clock, so we use a millisecond one. Works for the current benchmarks, at least.

@benknoble, I'll merge this PR as soon as I have benchmark results. But I don't know Racket so may be doing some stupid things. If you see something, please consider filing a PR fixing. 🙏 

A benchmark run: https://gist.github.com/PEZ/d78723c993744027a2fe3e39d4283db2
