### PR TITLE
Crystal: don't preallocate bufs to comply with new requirements

### DIFF
--- a/levenshtein/crystal/levenshtein.cr
+++ b/levenshtein/crystal/levenshtein.cr
@@ -1,40 +1,35 @@
 def levenshtein(strings : Array(String)) : Array(Int32)
-	# stolen from zig - reuse bufs
-	max_len = strings.map(&.size).max
-	buf1 = Array(Int32).new(max_len+1, 0)
-	buf2 = Array(Int32).new(max_len+1, 0)
-
 	strings.each_combination(2, reuse: true).map { |pair|
-		levenshtein_distance(pair[0], pair[1], buf1, buf2)
+		levenshtein_distance(pair[0], pair[1])
 	}.to_a
 end
 
-def levenshtein_distance(s1 : String, s2 : String, buf1 : Array(Int32), buf2 : Array(Int32)) : Int32
+def levenshtein_distance(s1 : String, s2 : String) : Int32
 	# Early termination checks
 	return s2.size if s1.empty?
 	return s1.size if s2.empty?
- 
+
 	# Make s1 the shorter string for space optimization
 	s1, s2 = s2, s1 if s1.size > s2.size
- 
+
 	m = s1.size
 	n = s2.size
- 
+
 	# Use two arrays instead of full matrix for space optimization
-	prev_row = buf1.fill {|i| i}
-	curr_row = buf2.fill(0)
- 
- 
+	prev_row = Array.new(m+1) {|i| i}
+	curr_row = Array.new(m+1, 0)
+
+
 	# Convert strings to bytes for faster access
 	s1_bytes = s1.to_slice
 	s2_bytes = s2.to_slice
- 
+
 	s2_bytes.each_with_index do |ch1, i|
 		curr_row[0] = i &+ 1
-  
+
 		s1_bytes.each_with_index do |ch2, j|
 		  cost = ch2 == ch1 ? 0 : 1
-		  
+
 		  # Calculate minimum of three operations
 		  curr_row[j &+ 1] = {
 			 prev_row[j &+ 1] &+ 1,  # deletion
@@ -42,9 +37,9 @@ def levenshtein_distance(s1 : String, s2 : String, buf1 : Array(Int32), buf2 : A
 			 prev_row[j] &+ cost     # substitution
 		  }.min
 		end
-  
+
 		prev_row, curr_row = curr_row, prev_row
 	 end
- 
+
 	prev_row[m]
  end


### PR DESCRIPTION
<!-- Thanks for helping to improve this project! 🙏 -->

I have:

* [x] Read the project [README](../../blob/main/README.md), including the [benchmark descriptions](../../blob/main/README.md#available-benchmarks)
* [x] Read the PR template instructions before I deleted them
* [x] Understood that if I have changed something that could impact performance of one or more contributions, I should provide results benchmark runs, using the `run.sh` script, from before and after the change.

## Description of changes

<!-- 

Please include a descrition for your change. Things like:

* Why it is done (a problem description)
  If there's an issue describing the problem, please refer it. If your PR is fixing the problem described in the issue, use the _Fixes #<issue-no>_  syntax.
* Why it is done the way you have done it (a solution description)

Please help us understand the changes and the rationale even if we are not experts or even familiar with the particular language you are providing changes for.

If you provide changes to the implementation of one or more language, for one or more benchmark, please include output from benchmark runs, using run.sh, from before and after the change. (TIPS: You can use a copy of run.sh to avoid running the benchmarks for other languages.) Please provide the results as text rather than as screen dumps.

Thanks again for contributing!
-->
We discussed this in the zig pr. Runs a little slower, as expected

before
![image](https://github.com/user-attachments/assets/32355772-e1a3-49f6-8961-76a47bf0aca0)


after
![image](https://github.com/user-attachments/assets/eebbcf9c-89c7-4ac7-80fd-3dd5abfaf588)


