### PR TITLE
Julia in process

### DIFF
--- a/fibonacci/julia/fibonacci-no-val.jl
+++ b/fibonacci/julia/fibonacci-no-val.jl
@@ -1,0 +1,13 @@
+module FibonacciNoVal
+
+export fibonacci
+
+function fibonacci(n::Int)::Int
+    if n < 2
+        return n
+    else
+        return fibonacci(n - 1) + fibonacci(n - 2)
+    end
+end
+
+end # module FibonacciNoVal

--- a/fibonacci/julia/fibonacci.jl
+++ b/fibonacci/julia/fibonacci.jl
@@ -1,0 +1,14 @@
+module Fibonacci
+
+export fibonacci
+
+# base case 1
+fibonacci(::Val{0}) = 0
+# base case 2
+fibonacci(::Val{1}) = 1
+# general case
+fibonacci(::Val{n}) where n = fibonacci(Val(n-1)) + fibonacci(Val(n-2))
+
+fibonacci(n::Int) = fibonacci(Val(n))
+
+end # module Fibonacci

--- a/fibonacci/julia/peek-asm.jl
+++ b/fibonacci/julia/peek-asm.jl
@@ -1,0 +1,27 @@
+#!/usr/bin/env julia
+# peek-asm.jl
+
+using InteractiveUtils
+
+include("fibonacci.jl")
+include("../../lib/julia/benchmark.jl")
+using .Fibonacci
+using .Benchmark
+
+function main()
+    if length(ARGS) < 1
+        println("Usage: julia peek-asm.jl <n>")
+        exit(1)
+    end
+
+    n = parse(Int, ARGS[1])
+
+    # Warmup run
+    Benchmark.run(() -> Fibonacci.fibonacci(n), 1000)
+
+    @code_native Fibonacci.fibonacci(Val(n))
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    main()
+end

--- a/fibonacci/julia/peek-asm.jl
+++ b/fibonacci/julia/peek-asm.jl
@@ -4,8 +4,10 @@
 using InteractiveUtils
 
 include("fibonacci.jl")
+include("fibonacci-no-val.jl")
 include("../../lib/julia/benchmark.jl")
 using .Fibonacci
+using .FibonacciNoVal
 using .Benchmark
 
 function main()
@@ -17,9 +19,15 @@ function main()
     n = parse(Int, ARGS[1])
 
     # Warmup run
-    Benchmark.run(() -> Fibonacci.fibonacci(n), 1000)
+    Benchmark.run(() -> Fibonacci.fibonacci(n), 100)
+    Benchmark.run(() -> FibonacciNoVal.fibonacci(n), 100)
 
+    println("Val version: ASM")
     @code_native Fibonacci.fibonacci(Val(n))
+
+    println("\n-----\n")
+    println("NoVal version: ASM")
+    @code_native FibonacciNoVal.fibonacci(n)
 end
 
 if abspath(PROGRAM_FILE) == @__FILE__

--- a/fibonacci/julia/run.jl
+++ b/fibonacci/julia/run.jl
@@ -1,0 +1,30 @@
+#!/usr/bin/env julia
+# run.jl
+
+include("fibonacci.jl")
+include("../../lib/julia/benchmark.jl")
+using .Fibonacci
+using .Benchmark
+
+function main()
+    if length(ARGS) < 3
+        println("Usage: julia run.jl <run-ms> <warmup-ms> <n>")
+        exit(1)
+    end
+
+    run_ms    = parse(Float64, ARGS[1])
+    warmup_ms = parse(Float64, ARGS[2])
+    n = parse(Int, ARGS[3])
+
+    # Warmup run
+    Benchmark.run(() -> Fibonacci.fibonacci(n), warmup_ms)
+
+    # Benchmark run
+    results = Benchmark.run(() -> Fibonacci.fibonacci(n), run_ms)
+
+    println(Benchmark.format_results(results))
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    main()
+end

--- a/hello-world/julia/run.jl
+++ b/hello-world/julia/run.jl
@@ -1,0 +1,4 @@
+#!/usr/bin/env julia
+# hello-world.jl
+
+println("Hello, World!")

--- a/languages.sh
+++ b/languages.sh
@@ -31,13 +31,14 @@ function run_languages {
   run 'Fortran' './fortran/run' './fortran/run'
   run 'Java' './jvm/run.class' 'java -cp .:../lib/java jvm.run'
   run 'Java Native' './java-native-image/run' './java-native-image/run'
+  run 'Julia' './julia/run.jl' 'julia ./julia/run.jl'
   run 'Objective C' './objc/run' './objc/run'
-  run "Python" "./py/run.py" "python3.12 ./py/run.py"
-  run "Python JIT" "./py-jit/run.py" "python3.12 ./py-jit/run.py"
-  run "Racket" './racket/run' './racket/run'
+  run 'Python' './py/run.py' 'python3.12 ./py/run.py'
+  run 'Python JIT' './py-jit/run.py' 'python3.12 ./py-jit/run.py'
+  run 'Racket' './racket/run' './racket/run'
   run 'Ruby' 'ruby/run.rb' 'ruby ruby/run.rb'
-  run "Ruby YJIT" "./ruby/code.rb" "ruby --yjit ./ruby/run.rb"
-  run "Rust" "./rust/target/release/run" "./rust/target/release/run"
-  run "Swift" "./swift/run" "./swift/run"
+  run 'Ruby YJIT' './ruby/code.rb' 'ruby --yjit ./ruby/run.rb'
+  run 'Rust' './rust/target/release/run' './rust/target/release/run'
+  run 'Swift' './swift/run' './swift/run'
   run 'Zig' './zig/zig-out/bin/run' './zig/zig-out/bin/run'
 }

--- a/levenshtein/julia/levenshtein.jl
+++ b/levenshtein/julia/levenshtein.jl
@@ -2,20 +2,21 @@ module Levenshtein
 
 export levenshtein_distance, distances
 
-# Calculates the Levenshtein distance between two strings using Wagner-Fischer algorithm
-# Space Complexity: O(min(m,n)) - only uses two arrays instead of full matrix
-# Time Complexity: O(m*n) where m and n are the lengths of the input strings
-function levenshtein_distance(
-    str1::String,
-    str2::String,
-    prev_row::Memory{Int32},
-    curr_row::Memory{Int32},
-)::Int
+# Calculates the Levenshtein distance between two strings using the Wagner-Fischer algorithm.
+# Space Complexity: O(min(m,n)) – allocates two arrays per call.
+# Time Complexity: O(m*n) where m and n are the lengths of the input strings.
+function levenshtein_distance(str1::String, str2::String)::Int
     # Early termination checks
-    str1 == str2 && return 0
-    (s1, s2) = (codeunits(str1), codeunits(str2))
-    isempty(s1) && return length(s2)
-    isempty(s2) && return length(s1)
+    if str1 == str2
+        return 0
+    end
+    s1 = codeunits(str1)
+    s2 = codeunits(str2)
+    if isempty(s1)
+        return length(s2)
+    elseif isempty(s2)
+        return length(s1)
+    end
 
     # Make s1 the shorter string for space optimization
     if length(s1) > length(s2)
@@ -24,27 +25,26 @@ function levenshtein_distance(
 
     m, n = length(s1), length(s2)
 
+    prev_row = Vector{Int32}(undef, m + 1)
+    curr_row = Vector{Int32}(undef, m + 1)
+
     # Initialize first row
     for i in 0:m
-        @inbounds prev_row[i + 1] = i % Int32
+        @inbounds prev_row[i + 1] = Int32(i)
     end
 
     # Main computation loop
     @inbounds for j in 1:n
-        curr_row[1] = j % Int32
-
+        curr_row[1] = Int32(j)
         for i in 1:m
             cost = s1[i] == s2[j] ? 0 : 1
-
-            # Calculate minimum of three operations
             @inbounds curr_row[i + 1] = min(
                 prev_row[i + 1] + 1,    # deletion
                 curr_row[i] + 1,        # insertion
                 prev_row[i] + cost      # substitution
-            ) % Int32
+            )
         end
-
-        # Swap rows
+        # Swap rows (we simply swap the array references)
         prev_row, curr_row = curr_row, prev_row
     end
 
@@ -54,22 +54,15 @@ end
 # distances : Vector{String} -> Vector{Int}
 #
 # Computes the Levenshtein distance for every unique unordered pair of strings.
-# That is, for each pair A, B (with A ≠ B) the distance is computed only once.
-# The function reuses two working arrays for performance.
+# That is, for each pair (A, B) with A ≠ B the distance is computed only once.
 function distances(strings::Vector{String})
     n = length(strings)
-    # There are n*(n-1)/2 unique pairs.
     count = n*(n-1) ÷ 2
     dists = Vector{Int}(undef, count)
-    # Determine the maximum number of codeunits in any string, and add one.
-    size = maximum(length.(codeunits.(strings))) + 1
-    v1 = Vector{Int32}(undef, size)
-    v2 = Vector{Int32}(undef, size)
     idx = 1
     for i in 1:(n-1)
         for j in (i+1):n
-            d = levenshtein_distance(strings[i], strings[j], v1, v2)
-            dists[idx] = d
+            dists[idx] = levenshtein_distance(strings[i], strings[j])
             idx += 1
         end
     end

--- a/levenshtein/julia/levenshtein.jl
+++ b/levenshtein/julia/levenshtein.jl
@@ -1,0 +1,79 @@
+module Levenshtein
+
+export levenshtein_distance, distances
+
+# Calculates the Levenshtein distance between two strings using Wagner-Fischer algorithm
+# Space Complexity: O(min(m,n)) - only uses two arrays instead of full matrix
+# Time Complexity: O(m*n) where m and n are the lengths of the input strings
+function levenshtein_distance(
+    str1::String,
+    str2::String,
+    prev_row::Memory{Int32},
+    curr_row::Memory{Int32},
+)::Int
+    # Early termination checks
+    str1 == str2 && return 0
+    (s1, s2) = (codeunits(str1), codeunits(str2))
+    isempty(s1) && return length(s2)
+    isempty(s2) && return length(s1)
+
+    # Make s1 the shorter string for space optimization
+    if length(s1) > length(s2)
+        s1, s2 = s2, s1
+    end
+
+    m, n = length(s1), length(s2)
+
+    # Initialize first row
+    for i in 0:m
+        @inbounds prev_row[i + 1] = i % Int32
+    end
+
+    # Main computation loop
+    @inbounds for j in 1:n
+        curr_row[1] = j % Int32
+
+        for i in 1:m
+            cost = s1[i] == s2[j] ? 0 : 1
+
+            # Calculate minimum of three operations
+            @inbounds curr_row[i + 1] = min(
+                prev_row[i + 1] + 1,    # deletion
+                curr_row[i] + 1,        # insertion
+                prev_row[i] + cost      # substitution
+            ) % Int32
+        end
+
+        # Swap rows
+        prev_row, curr_row = curr_row, prev_row
+    end
+
+    return @inbounds prev_row[m + 1]
+end
+
+# distances : Vector{String} -> Vector{Int}
+#
+# Computes the Levenshtein distance for every unique unordered pair of strings.
+# That is, for each pair A, B (with A ≠ B) the distance is computed only once.
+# The function reuses two working arrays for performance.
+function distances(strings::Vector{String})
+    n = length(strings)
+    # There are n*(n-1)/2 unique pairs.
+    count = n*(n-1) ÷ 2
+    dists = Vector{Int}(undef, count)
+    # Determine the maximum number of codeunits in any string, and add one.
+    size = maximum(length.(codeunits.(strings))) + 1
+    v1 = Vector{Int32}(undef, size)
+    v2 = Vector{Int32}(undef, size)
+    idx = 1
+    for i in 1:(n-1)
+        for j in (i+1):n
+            d = levenshtein_distance(strings[i], strings[j], v1, v2)
+            dists[idx] = d
+            idx += 1
+        end
+    end
+    return dists
+end
+
+end # module Levenshtein

--- a/levenshtein/julia/run.jl
+++ b/levenshtein/julia/run.jl
@@ -1,0 +1,35 @@
+#!/usr/bin/env julia
+# run.jl
+
+include("levenshtein.jl")
+include("../../lib/julia/benchmark.jl")
+using .Levenshtein
+using .Benchmark
+
+function main()
+    if length(ARGS) < 3
+        println("Usage: julia run.jl <run-ms> <warmup-ms> <file>")
+        exit(1)
+    end
+
+    run_ms    = parse(Float64, ARGS[1])
+    warmup_ms = parse(Float64, ARGS[2])
+    file      = ARGS[3]
+    strings = readlines(file)
+
+    # Warmup run using warmup_ms
+    Benchmark.run(() -> Levenshtein.distances(strings), warmup_ms)
+
+    # Benchmark run
+    results = Benchmark.run(() -> Levenshtein.distances(strings), run_ms)
+
+    total_distance = sum(results.result)
+    # Create a new results tuple with the total distance replacing the list of distances.
+    new_results = merge(results, (result = total_distance,))
+
+    println(Benchmark.format_results(new_results))
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    main()
+end

--- a/lib/julia/benchmark.jl
+++ b/lib/julia/benchmark.jl
@@ -1,0 +1,70 @@
+module Benchmark
+
+export run, format_results
+
+"""
+    run(f, run_ms)
+
+Runs the function `f` repeatedly until the total elapsed time exceeds `run_ms` milliseconds.
+If `run_ms` is 0, `f` is run once and dummy timing stats are returned.
+If `run_ms` is 1, status dots are not printed (this is assumed to be a correctness check).
+Returns a NamedTuple with keys:
+  - `runs`: number of iterations
+  - `result`: the result from the last call to `f`
+  - `mean_ms`, `min_ms`, `max_ms`, `std_dev_ms`: timing stats (in milliseconds)
+"""
+function run(f, run_ms::Real)
+    if run_ms == 0
+        return (runs = 0, result = f(), mean_ms = 0.0, min_ms = 0.0, max_ms = 0.0, std_dev_ms = 0.0)
+    end
+    run_ns = run_ms * 1e6  # convert milliseconds to nanoseconds
+    init_t = time_ns()
+    last_status_t = init_t
+    if run_ms > 1
+        print(stderr, ".")
+        flush(stderr)
+    end
+    results = Int64[]
+    runs = 0
+    total_elapsed = 0
+    result = nothing
+    while total_elapsed < run_ns
+        t0 = time_ns()
+        result = f()
+        t1 = time_ns()
+        elapsed = t1 - t0
+        push!(results, elapsed)
+        total_elapsed += elapsed
+        runs += 1
+        if run_ms > 1 && (t0 - last_status_t > 1e9)  # print dot if > 1 sec has passed
+            print(stderr, ".")
+            flush(stderr)
+            last_status_t = t0
+        end
+    end
+    if run_ms > 1
+        println(stderr)
+    end
+    mean_ns = total_elapsed / runs
+    min_ns = minimum(results)
+    max_ns = maximum(results)
+    variance = sum((t - mean_ns)^2 for t in results) / runs
+    std_dev_ns = sqrt(variance)
+    mean_ms = mean_ns / 1e6
+    min_ms = min_ns / 1e6
+    max_ms = max_ns / 1e6
+    std_dev_ms = std_dev_ns / 1e6
+    return (runs = runs, result = result, mean_ms = mean_ms, min_ms = min_ms, max_ms = max_ms, std_dev_ms = std_dev_ms)
+end
+
+"""
+    format_results(stats)
+
+Formats the benchmark results (a NamedTuple produced by `run`) as a comma‑separated string:
+`mean_ms,std_dev_ms,min_ms,max_ms,runs,result`
+"""
+function format_results(stats)
+    return string(stats.mean_ms, ",", stats.std_dev_ms, ",", stats.min_ms, ",", stats.max_ms, ",", stats.runs, ",", stats.result)
+end
+
+end # module Benchmark

--- a/loops/README.md
+++ b/loops/README.md
@@ -3,12 +3,15 @@
 This program should benchmark a function that makes 100 milion updates to an array,
 with some super simple math in each iteration. The code is designed to try force
 the compiler to generate code that actually makes 100 million updates. The code
-should be free of any hints to the compiler that the loops actually can be fully 
-unrolled. If some compiler or interpreter still finds ways to unroll the loops, 
-then that will be considered a valid result. 
+should be free of any hints to the compiler that the loops actually can be fully
+unrolled. If some compiler or interpreter still finds ways to unroll the loops,
+then that will be considered a valid result.
 
 The code should follow the reference implementations as closely as possible:
 
 * Clojure: [run.clj](clojure/run.clj)
 * Java: [run.java](jvm/run.java)
 * C: [run.c](c/run.c)
+
+Note: Like with the reference implementations the innermost sum should be assigned
+directly to the array index.

--- a/loops/julia/loops.jl
+++ b/loops/julia/loops.jl
@@ -3,16 +3,15 @@ module Loops
 export loops
 
 function loops(u::Int)::Int
-    a = zeros(Int, 10^4)
-    r = rand(1:10^4)
-    @inbounds for i in 1:10^4
-        local sum = 0
-        @inbounds @simd for j in 1:10^4
-            sum += j % u
+    a = zeros(Int, 10^4)          # Allocate an array of 10,000 zeros
+    r = rand(1:10^4)              # Choose a random index between 1 and 10,000
+    @inbounds for i in 1:10^4     # Outer loop over array indices
+        @inbounds for j in 1:10^4 # Inner loop: 10,000 iterations per outer loop iteration
+            a[i] += j % u         # Simple sum
         end
-        a[i] += sum + r
+        a[i] += r                 # Add a random value to each element in array
     end
-    return a[r]
+    return a[r]                   # Return the element at the random index
 end
 
-end # module Loops
+end  # module Loops

--- a/loops/julia/loops.jl
+++ b/loops/julia/loops.jl
@@ -1,0 +1,17 @@
+module Loops
+
+export loops
+
+function loops(u::Int)::Int
+    a = zeros(Int,10^4)
+    r = rand(1:10^4)
+    @inbounds for i ∈ 1:10^4
+        @inbounds for j ∈ 1:10^4
+            a[i] = a[i] + j%u
+        end
+        a[i] = a[i] + r
+    end
+    return a[r]
+end
+
+end # module Loops

--- a/loops/julia/loops.jl
+++ b/loops/julia/loops.jl
@@ -3,13 +3,14 @@ module Loops
 export loops
 
 function loops(u::Int)::Int
-    a = zeros(Int,10^4)
+    a = zeros(Int, 10^4)
     r = rand(1:10^4)
-    @inbounds for i ∈ 1:10^4
-        @inbounds for j ∈ 1:10^4
-            a[i] = a[i] + j%u
+    @inbounds for i in 1:10^4
+        local sum = 0
+        @inbounds @simd for j in 1:10^4
+            sum += j % u
         end
-        a[i] = a[i] + r
+        a[i] += sum + r
     end
     return a[r]
 end

--- a/loops/julia/run.jl
+++ b/loops/julia/run.jl
@@ -1,0 +1,30 @@
+#!/usr/bin/env julia
+# run.jl
+
+include("loops.jl")
+include("../../lib/julia/benchmark.jl")
+using .Loops
+using .Benchmark
+
+function main()
+    if length(ARGS) < 3
+        println("Usage: julia run.jl <run-ms> <warmup-ms> <input>")
+        exit(1)
+    end
+
+    run_ms    = parse(Float64, ARGS[1])
+    warmup_ms = parse(Float64, ARGS[2])
+    u = parse(Int, ARGS[3])
+
+    # Warmup run
+    Benchmark.run(() -> Loops.loops(u), warmup_ms)
+
+    # Benchmark run
+    results = Benchmark.run(() -> Loops.loops(u), run_ms)
+
+    println(Benchmark.format_results(results))
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    main()
+end


### PR DESCRIPTION
<!-- Thanks for helping to improve this project! 🙏 -->

I have:

* [x] Read the project [README](../../blob/main/README.md), including the [benchmark descriptions](../../blob/main/README.md#available-benchmarks)
* [x] Read the PR template instructions before I deleted them
* [x] Understood that if I have changed something that could impact performance of one or more contributions, I should provide results benchmark runs, using the `run.sh` script, from before and after the change.

## Description of changes

Moving the Julia programs over to the in-process runner. We have a new Fibonacci champion. The Julia compiler manages to fold the recursion entirely and just replaces the call to `fibonacci(37)` with the result. I added a version of fibonacci function that really forces the recursion, and it performs decently, at the level of other fast languages. But the benchmark rules does allow for solving it in this folding way, as far as I understand them (and I wrote them for this incarnation of the benchmark...). I also added a `fibonacci/julia/peek-asm.jl` file there for easy inspection of the assembly produced for both versions.

Benchmarks:

https://github.com/user-attachments/assets/2d2aa8d1-a1f4-4477-ae83-f22bb9220f3b

* Closes #410 


