### PR TITLE
Adds Kotlin benchmarking support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ zig-out
 */clojure-native-image/run
 */java-native-image/jvm.run
 */java-native-image/run
+*/kotlin/META-INF/
 loops/*/code
 loops/*/run
 fibonacci/*/code

--- a/clean.sh
+++ b/clean.sh
@@ -16,6 +16,8 @@ function clean_benchmark {
   rm scala/code scala/code-native
   rm -rf rust/{Cargo.lock,target} ../lib/rust/{Cargo.lock,target}
   rm -rf kotlin/code.jar
+  rm -rf kotlin/META-INF
+  rm -rf kotlin/*.class
   rm kotlin/code.kexe
   rm dart/code
   rm -rf inko/build inko/code

--- a/fibonacci/kotlin/run.kt
+++ b/fibonacci/kotlin/run.kt
@@ -2,9 +2,9 @@ import languages.Benchmark
 
 fun main(args: Array<String>) {
     val runMs = args[0].toLong();
-    val warmupMS = args[1].toLong();
+    val warmupMs = args[1].toLong();
     var n = args[2].toInt()
-    Benchmark.run( { fibonacci(n) }, warmupMS);
+    Benchmark.run({ fibonacci(n) }, warmupMs);
     val results = Benchmark.run({ fibonacci(n) }, runMs);
     println(Benchmark.formatResults(results));
 }

--- a/fibonacci/kotlin/run.kt
+++ b/fibonacci/kotlin/run.kt
@@ -1,0 +1,11 @@
+import languages.Benchmark
+
+fun main(args: Array<String>) {
+    val runMs = args[0].toLong();
+    val warmupMS = args[1].toLong();
+    var n = args[2].toInt()
+    Benchmark.run( { fibonacci(n) }, warmupMS);
+    val results = Benchmark.run({ fibonacci(n) }, runMs);
+    println(Benchmark.formatResults(results));
+}
+

--- a/hello-world/kotlin/run.kt
+++ b/hello-world/kotlin/run.kt
@@ -1,0 +1,3 @@
+fun main() {
+    println("Hello, world!")
+}

--- a/languages.sh
+++ b/languages.sh
@@ -16,6 +16,7 @@ function compile_languages {
   compile 'Gleam' 'maelg' '(cd maelg && gleam build --target erlang)'
   compile 'Java' 'jvm' 'javac -cp ../lib/java jvm/*.java'
   compile 'Java Native' 'java-native-image' '(cd java-native-image ; native-image -cp ..:../../lib/java --no-fallback -O3 --pgo-instrument -march=native jvm.run) && ./java-native-image/jvm.run -XX:ProfilesDumpFile=java-native-image/run.iprof 10000 2000 $(./check-output.sh -i) && (cd java-native-image ; native-image -cp ..:../../lib/java -O3 --pgo=run.iprof -march=native jvm.run -o run)'
+  compile 'Kotlin' 'kotlin' 'javac ../lib/java/*/*.java && kotlinc -cp ../lib/java kotlin/*.kt -d kotlin'
   compile 'Objective C' 'objc' 'clang -O3 -I../lib/c -framework Foundation objc/*.m ../lib/c/benchmark.c -o objc/run'
   compile 'Racket' 'racket' '(cd racket && raco make run.rkt && raco demod -o run.zo run.rkt && raco exe -o run run.zo)'
   compile 'Rust' 'rust' 'cargo build --manifest-path rust/Cargo.toml --release'
@@ -37,6 +38,7 @@ function run_languages {
   run 'Gleam' './maelg/build/dev/erlang/run/ebin/run.beam' "./maelg/run.sh"
   run 'Java' './jvm/run.class' 'java -cp .:../lib/java jvm.run'
   run 'Java Native' './java-native-image/run' './java-native-image/run'
+  run 'Kotlin' './kotlin/RunKt.class' 'kotlin -cp kotlin:../lib/java RunKt'
   run 'Julia' './julia/run.jl' 'julia ./julia/run.jl'
   run 'Objective C' './objc/run' './objc/run'
   run 'Python' './py/run.py' 'python3.12 ./py/run.py'

--- a/levenshtein/kotlin/run.kt
+++ b/levenshtein/kotlin/run.kt
@@ -1,0 +1,25 @@
+import java.io.File
+import languages.Benchmark
+
+fun distances(strings: List<String>): List<Int> {
+    val distances = mutableListOf<Int>()
+    // Compare all pairs and store their distances
+    for (i in strings.indices) {
+        val start = i + 1
+        for (j in start..strings.lastIndex) {
+            distances += levenshteinDistance(strings[i], strings[j]);
+        }
+    }
+    return distances;
+}
+
+fun main(args: Array<String>) {
+    val runMs = args[0].toLong()
+    val warmupMS = args[1].toLong()
+    val inputPath = args[2];
+    val strings = File(inputPath).readLines()
+    Benchmark.run({ distances(strings) }, warmupMS);
+    val results = Benchmark.run({ distances(strings) }, runMs);
+    val summedResults = results.withResult(results.result().sum())
+    println(Benchmark.formatResults(summedResults));
+}

--- a/levenshtein/kotlin/run.kt
+++ b/levenshtein/kotlin/run.kt
@@ -15,10 +15,10 @@ fun distances(strings: List<String>): List<Int> {
 
 fun main(args: Array<String>) {
     val runMs = args[0].toLong()
-    val warmupMS = args[1].toLong()
+    val warmupMs = args[1].toLong()
     val inputPath = args[2];
     val strings = File(inputPath).readLines()
-    Benchmark.run({ distances(strings) }, warmupMS);
+    Benchmark.run({ distances(strings) }, warmupMs);
     val results = Benchmark.run({ distances(strings) }, runMs);
     val summedResults = results.withResult(results.result().sum())
     println(Benchmark.formatResults(summedResults));

--- a/loops/kotlin/run.kt
+++ b/loops/kotlin/run.kt
@@ -15,9 +15,9 @@ fun loops(u: Int): Int{
 
 fun main(args: Array<String>) {
     val runMs = args[0].toLong()
-    val warmupMS = args[1].toLong()
+    val warmupMs = args[1].toLong()
     val n = args[2].toInt()
-    Benchmark.run( { loops(n) }, warmupMS);
-    val results = Benchmark.run( { loops(n) }, runMs);
+    Benchmark.run({ loops(n) }, warmupMs);
+    val results = Benchmark.run({ loops(n) }, runMs);
     println(Benchmark.formatResults(results));
 }

--- a/loops/kotlin/run.kt
+++ b/loops/kotlin/run.kt
@@ -1,0 +1,23 @@
+import languages.Benchmark
+import kotlin.random.Random
+
+fun loops(u: Int): Int{
+    val r: Int = Random.nextInt(10_000)
+    val a = IntArray(10_000)
+    for (i in 0..<10_000) {
+        for (j in 0..<10_000) {
+            a[i] = a[i] + j % u
+        }
+        a[i] = a[i] + r
+    }
+    return a[r]
+}
+
+fun main(args: Array<String>) {
+    val runMs = args[0].toLong()
+    val warmupMS = args[1].toLong()
+    val n = args[2].toInt()
+    Benchmark.run( { loops(n) }, warmupMS);
+    val results = Benchmark.run( { loops(n) }, runMs);
+    println(Benchmark.formatResults(results));
+}


### PR DESCRIPTION
<!-- Thanks for helping to improve this project! 🙏 -->

I have:

* [x] Read the project [README](../../blob/main/README.md), including the [benchmark descriptions](../../blob/main/README.md#available-benchmarks)
* [x] Read the PR template instructions before I deleted them
* [x] Understood that if I have changed something that could impact performance of one or more contributions, I should provide results benchmark runs, using the `run.sh` script, from before and after the change.

## Description of changes

Adds Kotlin benchmarking support.

Adds a `run.kt` file for each benchmark and support in `languages.sh` for compiling and running this file. For fibonacci and levenshtein, `run.kt` can re-use functions defined in `code.kt`.

This uses the Benchmark library in `lib/java/languages`. The code that invokes this library is a direct port of the Java version.

Kotlin Output:
```
benchmark,timestamp,commit-sha,is-checked,user,model,ram,os,arch,gcc,g++,llvm,clang,language,run-ms,mean-ms,std-dev-ms,min-ms,max-ms,runs
loops,2025-08-16T08:32:29Z,480d9c5,true,JDoe,Apple M1 Pro,16GB,darwin24,arm64,Apple clang version 17.0.0 (clang-1700.0.13.5),Apple clang version 17.0.0 (clang-1700.0.13.5),,Apple clang version 17.0.0 (clang-1700.0.13.5),Kotlin,10000,63.831934,0.533146,62.904000,65.854166,157
fibonacci,2025-08-16T08:32:29Z,480d9c5,true,JDoe,Apple M1 Pro,16GB,darwin24,arm64,Apple clang version 17.0.0 (clang-1700.0.13.5),Apple clang version 17.0.0 (clang-1700.0.13.5),,Apple clang version 17.0.0 (clang-1700.0.13.5),Kotlin,10000,76.130391,1.462450,74.974042,88.884459,132
levenshtein,2025-08-16T08:32:29Z,480d9c5,true,JDoe,Apple M1 Pro,16GB,darwin24,arm64,Apple clang version 17.0.0 (clang-1700.0.13.5),Apple clang version 17.0.0 (clang-1700.0.13.5),,Apple clang version 17.0.0 (clang-1700.0.13.5),Kotlin,10000,165.181131,2.849853,162.623542,181.744583,61
hello-world,2025-08-16T08:32:29Z,480d9c5,true,JDoe,Apple M1 Pro,16GB,darwin24,arm64,Apple clang version 17.0.0 (clang-1700.0.13.5),Apple clang version 17.0.0 (clang-1700.0.13.5),,Apple clang version 17.0.0 (clang-1700.0.13.5),Kotlin,10000,105.774,6.26934,98.1845,120.028,25
```

Java Output (unchanged):
```
benchmark,timestamp,commit-sha,is-checked,user,model,ram,os,arch,gcc,g++,llvm,clang,language,run-ms,mean-ms,std-dev-ms,min-ms,max-ms,runs
loops,2025-08-16T08:38:20Z,480d9c5,true,JDoe,Apple M1 Pro,16GB,darwin24,arm64,Apple clang version 17.0.0 (clang-1700.0.13.5),Apple clang version 17.0.0 (clang-1700.0.13.5),,Apple clang version 17.0.0 (clang-1700.0.13.5),Java,10000,63.345606,0.613419,62.899208,66.306958,158
fibonacci,2025-08-16T08:38:20Z,480d9c5,true,JDoe,Apple M1 Pro,16GB,darwin24,arm64,Apple clang version 17.0.0 (clang-1700.0.13.5),Apple clang version 17.0.0 (clang-1700.0.13.5),,Apple clang version 17.0.0 (clang-1700.0.13.5),Java,10000,63.769066,0.583488,63.268208,65.810333,157
levenshtein,2025-08-16T08:38:20Z,480d9c5,true,JDoe,Apple M1 Pro,16GB,darwin24,arm64,Apple clang version 17.0.0 (clang-1700.0.13.5),Apple clang version 17.0.0 (clang-1700.0.13.5),,Apple clang version 17.0.0 (clang-1700.0.13.5),Java,10000,78.619433,0.916873,76.650291,81.013958,128
hello-world,2025-08-16T08:38:20Z,480d9c5,true,JDoe,Apple M1 Pro,16GB,darwin24,arm64,Apple clang version 17.0.0 (clang-1700.0.13.5),Apple clang version 17.0.0 (clang-1700.0.13.5),,Apple clang version 17.0.0 (clang-1700.0.13.5),Java,10000,34.2435,0.947087,32.6528,36.0748,25
```
